### PR TITLE
Add nginx test and BPF network checks, add webserver_test policy

### DIFF
--- a/config/policy.json
+++ b/config/policy.json
@@ -38,7 +38,7 @@
       "flags": {
         "allow_file_access": true,
         "allow_network": true,
-        "allow_exec": false,
+        "allow_exec": true,
         "require_signed_binary": false,
         "allow_setuid": false,
         "allow_ptrace": false
@@ -135,6 +135,26 @@
         {"protocol": "tcp", "port": 5432, "allow": true},
         {"protocol": "tcp", "port": 6379, "allow": true},
         {"protocol": "tcp", "port": 5672, "allow": true}
+      ],
+      "execution_rules": [],
+      "require_signed_binary": false
+    },
+    "webserver_test": {
+      "id": 8,
+      "name": "webserver_test",
+      "flags": {
+        "allow_file_access": true,
+        "allow_network": false,
+        "allow_exec": true,
+        "require_signed_binary": false,
+        "allow_setuid": false,
+        "allow_ptrace": false
+      },
+      "file_paths": [],
+      "network_rules": [
+        {"protocol": "tcp", "port": 80, "allow": true},
+        {"protocol": "tcp", "port": 443, "allow": true},
+        {"protocol": "tcp", "port": 8080, "allow": true}
       ],
       "execution_rules": [],
       "require_signed_binary": false

--- a/tests/nginx/nginx.conf
+++ b/tests/nginx/nginx.conf
@@ -1,0 +1,22 @@
+# Default nginx config for BpfJailer testing
+# Uses port 8080 (allowed by webserver_test role)
+worker_processes 1;
+error_log /dev/stderr info;
+
+events {
+    worker_connections 64;
+}
+
+http {
+    access_log /dev/stdout;
+
+    server {
+        listen 8080;
+        server_name localhost;
+
+        location / {
+            return 200 'BpfJailer nginx test running\n';
+            add_header Content-Type text/plain;
+        }
+    }
+}

--- a/tests/nginx/nginx.py
+++ b/tests/nginx/nginx.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import socket, json, os, sys
+
+NGINX_BIN = os.environ.get("NGINX_BIN", "/usr/sbin/nginx")
+
+# Get config file from args
+config_file = sys.argv[1] if len(sys.argv) > 1 else None
+role_id = int(sys.argv[2]) if len(sys.argv) > 2 else 3
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect("/run/bpfjailer/enrollment.sock")
+
+# Enroll with specified role (default: webserver role ID 3)
+request = {"Enroll": {"pod_id": 1, "role_id": role_id}}
+sock.send((json.dumps(request) + "\n").encode())
+response = sock.recv(4096).decode()
+sock.close()
+print(f"Enrollment: {response}")
+
+# Build nginx args
+args = ["nginx", "-g", "daemon off;"]
+if config_file:
+    args = ["nginx", "-c", config_file, "-g", "daemon off;"]
+
+os.execv(NGINX_BIN, args)

--- a/tests/nginx/nginx_allow.conf
+++ b/tests/nginx/nginx_allow.conf
@@ -1,0 +1,25 @@
+# nginx_allow.conf - Works with webserver_test role (ports 80, 443, 8080 allowed)
+worker_processes 1;
+error_log /tmp/nginx_test_good.log info;
+
+events {
+    worker_connections 64;
+}
+
+http {
+    access_log /tmp/nginx_test_good_access.log;
+
+    server {
+        listen 8080;  # ALLOWED by webserver_test role
+        server_name localhost;
+
+        location / {
+            return 200 'BpfJailer test: Port 8080 allowed\n';
+            add_header Content-Type text/plain;
+        }
+
+        location /health {
+            return 200 'OK\n';
+        }
+    }
+}

--- a/tests/nginx/nginx_blocked.conf
+++ b/tests/nginx/nginx_blocked.conf
@@ -1,0 +1,21 @@
+# nginx_blocked.conf - BLOCKED by webserver_test role
+# Attempts to bind port 9000 (not in allowed list: 80, 443, 8080)
+worker_processes 1;
+error_log /tmp/nginx_test_bad.log info;
+
+events {
+    worker_connections 64;
+}
+
+http {
+    access_log /tmp/nginx_test_bad_access.log;
+
+    server {
+        listen 9000;  # BLOCKED - port not allowed for webserver_test role
+        server_name localhost;
+
+        location / {
+            return 200 'This should never be reachable\n';
+        }
+    }
+}

--- a/tests/nginx/run_test.sh
+++ b/tests/nginx/run_test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Test script demonstrating BpfJailer policy enforcement on nginx
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=========================================="
+echo "BpfJailer nginx Policy Test"
+echo "=========================================="
+echo ""
+echo "webserver_test role (ID 8) allows: TCP 80, 443, 8080"
+echo ""
+
+# Check if daemon is running
+if [ ! -S /run/bpfjailer/enrollment.sock ]; then
+    echo "ERROR: BpfJailer daemon not running"
+    echo "Start with: sudo RUST_LOG=info ./target/release/bpfjailer-daemon"
+    exit 1
+fi
+
+run_nginx_test() {
+    local config=$1
+    local description=$2
+    local role_id=${3:-8}
+
+    echo "----------------------------------------"
+    echo "TEST: $description"
+    echo "Config: $config"
+    echo "Role ID: $role_id"
+    echo "----------------------------------------"
+
+    # Enroll and run nginx using nginx.py
+    python3 "$SCRIPT_DIR/nginx.py" "$config" "$role_id" 2>&1 &
+    local pid=$!
+    sleep 1
+
+    # Check if nginx is still running
+    if kill -0 $pid 2>/dev/null; then
+        echo "RESULT: nginx started successfully"
+        kill $pid 2>/dev/null
+        wait $pid 2>/dev/null
+    else
+        echo "RESULT: nginx failed to start (blocked by BpfJailer)"
+    fi
+    echo ""
+}
+
+echo ""
+echo "TEST 1: Port 8080 - ALLOWED"
+run_nginx_test "$SCRIPT_DIR/nginx_allow.conf" "Port 8080 (allowed)"
+
+sleep 1
+
+echo ""
+echo "TEST 2: Port 9000 - BLOCKED"
+run_nginx_test "$SCRIPT_DIR/nginx_blocked.conf" "Port 9000 (blocked)"
+
+echo "=========================================="
+echo "Test complete"
+echo "=========================================="


### PR DESCRIPTION
- Enhance BPF network checks, add webserver_test policy
- Created nginx_allow.conf to test allowed port 8080
- Created nginx_blocked.conf to test blocked port 9000
- Added nginx.conf as a default configuration for testing
- Implemented nginx.py for running nginx with specified configurations
- Developed run_test.sh to automate testing of BpfJailer policy enforcement