### PR TITLE
feat: Add daemonless mode with bootstrap binary for BpfJailer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bpfjailer-bootstrap"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bpfjailer-common",
+ "env_logger",
+ "libbpf-rs",
+ "libbpf-sys",
+ "libc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bpfjailer-bpf"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "bpfjailer-bpf",
     "bpfjailer-client",
     "bpfjailer-daemon",
+    "bpfjailer-bootstrap",
 ]
 exclude = [
     "test_task_storage",

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# BpfJailer - eBPF Mandatory Access Control
+# Jailer - eBPF Mandatory Access Control
 
 > **Warning**: This project is under heavy development and is **NOT ready for production use**. APIs, policy formats, and behavior may change without notice. Use for testing and experimentation only.
+
+## Acknowledgments
+
+> **Note**: This is an independent implementation and is not the same project as Meta's solution. While BpfJailer is functionally similar and inspired by the original idea and design by **Liam Wisehart**,  **Justin Nga**, **Carl El Khoury**, **Mansee Chadha**  at **Meta**, this is a separate codebase developed independently. We extend our gratitude for the vision and foundational concepts that inspired this work.
 
 # Community
 [![Join us on Discord](https://img.shields.io/badge/Join%20Us%20on-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/jzsW5Q6s9q)
 [![Substack](https://img.shields.io/badge/Substack-FF6719?logo=substack&logoColor=fff)](https://arxignis.substack.com/)
 
-BpfJailer is an eBPF-based process jailing system that provides mandatory access control (MAC) for Linux. It tracks processes using BPF task_storage maps and enforces role-based policies on file access, network operations, and process execution.
+Jailer is an eBPF-based process jailing system that provides mandatory access control (MAC) for Linux. It tracks processes using BPF task_storage maps and enforces role-based policies on file access, network operations, and process execution.
 
 ## Features (Current Version)
 
@@ -572,7 +576,3 @@ getfattr -d /path/to/binary
 ## License
 
 GPL-2.0 (required for BPF programs)
-
-## Acknowledgments
-
-This project is based on the original idea and design by **Liam Wisehart** at **Meta**. Special thanks for the vision and foundational work that made BpfJailer possible.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ BpfJailer is an eBPF-based process jailing system that provides mandatory access
 | Path Matching | ✅ Working | Dentry walking with cache invalidation |
 | Signed Binaries | 🚧 Stub | Binary signature validation (not implemented) |
 | Alternative Enrollment | ✅ Working | Auto-enroll by executable, cgroup, or xattr |
+| Daemonless Mode | ✅ Working | Bootstrap binary pins programs at early boot |
+| Audit Events | ✅ Working | Perf buffer for systemd-journald integration |
 
 ## Nginx demo
 ![Nginx demo](./tests/nginx/demo.gif)
@@ -381,6 +383,82 @@ Port ranges can be specified in policy.json using `port_start` and `port_end`:
 4. On next syscall (file_open, exec), BPF migrates enrollment to `task_storage`
 5. All future syscalls check `task_storage` + `role_flags` for enforcement
 6. Child processes inherit via `task_alloc` hook
+
+## Installation Modes
+
+BpfJailer supports two installation modes:
+
+### 1. Daemon Mode (Standard)
+
+Uses a running daemon for enrollment and policy management:
+
+```bash
+# Install systemd service
+sudo cp config/bpfjailer-daemon.service /etc/systemd/system/
+sudo cp target/release/bpfjailer-daemon /usr/sbin/
+sudo mkdir -p /etc/bpfjailer
+sudo cp config/policy.json /etc/bpfjailer/
+
+# Enable and start
+sudo systemctl daemon-reload
+sudo systemctl enable bpfjailer-daemon
+sudo systemctl start bpfjailer-daemon
+```
+
+**Features:**
+- Socket-based enrollment API
+- Hot policy reload (stop/start daemon)
+- Full logging in daemon process
+
+### 2. Daemonless Mode (Bootstrap)
+
+Loads BPF programs at early boot and exits. Programs remain active until reboot:
+
+```bash
+# Install bootstrap service
+sudo cp config/bpfjailer-bootstrap.service /etc/systemd/system/
+sudo cp target/release/bpfjailer-bootstrap /usr/sbin/
+sudo mkdir -p /etc/bpfjailer
+sudo cp config/policy.json /etc/bpfjailer/
+
+# Enable (will run at next boot)
+sudo systemctl daemon-reload
+sudo systemctl enable bpfjailer-bootstrap
+
+# Or run manually now
+sudo bpfjailer-bootstrap
+```
+
+**Features:**
+- No running daemon (reduced attack surface)
+- BPF programs pinned to `/sys/fs/bpf/bpfjailer/`
+- Cannot be stopped without reboot
+- Audit events sent to systemd-journald via perf buffer
+- Only alternative enrollment methods work (exec/cgroup/xattr)
+
+**Check pinned programs:**
+```bash
+ls -la /sys/fs/bpf/bpfjailer/
+ls -la /sys/fs/bpf/bpfjailer/maps/
+ls -la /sys/fs/bpf/bpfjailer/progs/
+```
+
+**View audit events:**
+```bash
+# Events are emitted to perf buffer, picked up by journald
+journalctl -f | grep bpfjailer
+```
+
+### Mode Comparison
+
+| Aspect | Daemon Mode | Daemonless Mode |
+|--------|-------------|-----------------|
+| Attack Surface | Running daemon | No running process |
+| Enrollment | Unix socket + alternatives | Alternatives only |
+| Policy Updates | Hot reload | Reboot required |
+| Audit Logging | Daemon reads ringbuf | journald via perf buffer |
+| Program Removal | Stop daemon | Reboot only |
+| Boot Order | After network.target | Before basic.target |
 
 ## Troubleshooting
 

--- a/bpfjailer-bootstrap/Cargo.toml
+++ b/bpfjailer-bootstrap/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bpfjailer-bootstrap"
+version = "0.1.0"
+edition = "2021"
+description = "BpfJailer bootstrap loader for daemonless installation"
+
+[[bin]]
+name = "bpfjailer-bootstrap"
+path = "src/main.rs"
+
+[dependencies]
+bpfjailer-common = { path = "../bpfjailer-common" }
+libbpf-rs = "0.21"
+libbpf-sys = "1.4"
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+libc = "0.2"

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -1,0 +1,456 @@
+//! BpfJailer Bootstrap - Daemonless Installation
+//!
+//! Loads and pins BPF programs/maps at early boot.
+//! After setup, exits immediately. Programs remain active until reboot.
+
+use anyhow::{Context, Result};
+use bpfjailer_common::policy::PolicyConfig;
+use libbpf_rs::{Link, MapFlags, Object, ObjectBuilder};
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+const BPF_PIN_PATH: &str = "/sys/fs/bpf/bpfjailer";
+const DEFAULT_POLICY_PATH: &str = "/etc/bpfjailer/policy.json";
+const LOCAL_POLICY_PATH: &str = "config/policy.json";
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    if let Err(e) = run() {
+        log::error!("Bootstrap failed: {:#}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    log::info!("BpfJailer bootstrap starting...");
+
+    // Check if already pinned
+    if is_pinned() {
+        log::info!("BPF programs already pinned at {}", BPF_PIN_PATH);
+        log::info!("To reload, remove {} and rerun", BPF_PIN_PATH);
+        return Ok(());
+    }
+
+    // Load policy
+    let policy = load_policy()?;
+    log::info!("Loaded {} roles from policy", policy.roles.len());
+
+    // Load BPF object
+    let (mut object, mut links) = load_bpf_object()?;
+
+    // Populate maps from policy
+    populate_maps(&mut object, &policy)?;
+
+    // Pin maps and programs
+    pin_all(&mut object, &mut links)?;
+
+    log::info!("BpfJailer bootstrap complete - programs pinned and active");
+    log::info!("Programs will remain active until reboot");
+    Ok(())
+}
+
+fn is_pinned() -> bool {
+    Path::new(BPF_PIN_PATH).exists()
+}
+
+fn load_policy() -> Result<PolicyConfig> {
+    let policy_path = std::env::var("BPFJAILER_POLICY").ok().or_else(|| {
+        if Path::new(DEFAULT_POLICY_PATH).exists() {
+            Some(DEFAULT_POLICY_PATH.to_string())
+        } else if Path::new(LOCAL_POLICY_PATH).exists() {
+            Some(LOCAL_POLICY_PATH.to_string())
+        } else {
+            None
+        }
+    });
+
+    let path = policy_path.ok_or_else(|| {
+        anyhow::anyhow!(
+            "No policy file found. Set BPFJAILER_POLICY or create {}",
+            DEFAULT_POLICY_PATH
+        )
+    })?;
+
+    log::info!("Loading policy from: {}", path);
+    let content = fs::read_to_string(&path).context("Failed to read policy file")?;
+    let config: PolicyConfig = serde_json::from_str(&content).context("Failed to parse policy")?;
+    Ok(config)
+}
+
+fn load_bpf_object() -> Result<(Object, Vec<Link>)> {
+    log::info!("Loading BPF programs...");
+
+    let workspace_root = std::env::var("CARGO_MANIFEST_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let possible_paths = [
+        PathBuf::from("/usr/lib/bpfjailer/bpfjailer.bpf.o"),
+        PathBuf::from("/usr/share/bpfjailer/bpfjailer.bpf.o"),
+        workspace_root.join("target/bpfel-unknown-none/release/bpfjailer.bpf.o"),
+        workspace_root.join("target/bpfel-unknown-none/debug/bpfjailer.bpf.o"),
+        workspace_root.join("bpfjailer-bpf/target/bpfel-unknown-none/release/bpfjailer.bpf.o"),
+        workspace_root.join("bpfjailer-bpf/target/bpfel-unknown-none/debug/bpfjailer.bpf.o"),
+        PathBuf::from("target/bpfel-unknown-none/release/bpfjailer.bpf.o"),
+        PathBuf::from("target/bpfel-unknown-none/debug/bpfjailer.bpf.o"),
+    ];
+
+    let obj_path = possible_paths
+        .iter()
+        .find(|p| p.exists())
+        .ok_or_else(|| anyhow::anyhow!("bpfjailer.bpf.o not found"))?;
+
+    log::info!("Loading BPF object from: {:?}", obj_path);
+
+    let mut object_builder = ObjectBuilder::default();
+    let open_object = object_builder.open_file(obj_path)?;
+    let mut object = open_object.load().context("Failed to load BPF object")?;
+
+    log::info!("BPF object loaded successfully");
+
+    // Attach LSM programs
+    let program_names = [
+        "task_alloc",
+        "file_open",
+        "socket_bind",
+        "socket_connect",
+        "bprm_check_security",
+        "path_rename",
+        "sb_mount",
+        "sb_umount",
+    ];
+
+    let mut links = Vec::new();
+    for name in &program_names {
+        if let Some(prog) = object.prog_mut(name) {
+            let link = prog
+                .attach()
+                .with_context(|| format!("Failed to attach {}", name))?;
+            log::info!("Attached: {}", name);
+            links.push(link);
+        } else {
+            log::warn!("Program {} not found", name);
+        }
+    }
+
+    Ok((object, links))
+}
+
+fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
+    log::info!("Populating BPF maps from policy...");
+
+    // Load roles and their flags
+    for (name, role) in &policy.roles {
+        let role_id = role.id.0;
+        let flags = flags_to_byte(&role.flags);
+
+        // Update role_flags map
+        if let Some(map) = object.map("role_flags") {
+            let key = role_id.to_ne_bytes();
+            let value = [flags];
+            map.update(&key, &value, MapFlags::empty())?;
+            log::info!("Role '{}' (id={}) flags={:#x}", name, role_id, flags);
+        }
+
+        // Load network rules
+        if let Some(map) = object.map("network_rules") {
+            for rule in &role.network_rules {
+                let protocol = match rule.protocol.as_str() {
+                    "tcp" | "TCP" => 6u8,
+                    "udp" | "UDP" => 17u8,
+                    _ => continue,
+                };
+
+                let ports: Vec<u16> = if let Some(port) = rule.port {
+                    vec![port]
+                } else if let (Some(start), Some(end)) = (rule.port_start, rule.port_end) {
+                    (start..=end).collect()
+                } else {
+                    continue;
+                };
+
+                for port in ports {
+                    // Add both bind and connect rules
+                    for direction in [0u8, 1u8] {
+                        let mut key = [0u8; 8];
+                        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
+                        key[4..6].copy_from_slice(&port.to_ne_bytes());
+                        key[6] = protocol;
+                        key[7] = direction;
+                        let value = [if rule.allow { 1u8 } else { 0u8 }];
+                        map.update(&key, &value, MapFlags::empty())?;
+                    }
+                }
+            }
+        }
+
+        // Load path rules (state machine)
+        if let Some(map) = object.map("path_states") {
+            for path_rule in &role.file_paths {
+                add_path_state(map, role_id, &path_rule.pattern, path_rule.allow)?;
+            }
+        }
+    }
+
+    // Load pod mappings
+    if let Some(map) = object.map("pod_to_role") {
+        for pod in &policy.pods {
+            let key = pod.id.to_ne_bytes();
+            let value = pod.role_id.0.to_ne_bytes();
+            map.update(&key, &value, MapFlags::empty())?;
+            log::info!("Pod {} -> role {}", pod.id, pod.role_id.0);
+        }
+    }
+
+    // Load exec enrollments
+    if let Some(map) = object.map("exec_enrollment") {
+        for enrollment in &policy.exec_enrollments {
+            if let Ok(metadata) = fs::metadata(&enrollment.executable_path) {
+                let inode = metadata.ino();
+                if let Some(role) = policy.get_role(&enrollment.role) {
+                    let key = inode.to_ne_bytes();
+                    let mut value = [0u8; 16];
+                    value[0..8].copy_from_slice(&enrollment.pod_id.to_ne_bytes());
+                    value[8..12].copy_from_slice(&role.id.0.to_ne_bytes());
+                    map.update(&key, &value, MapFlags::empty())?;
+                    log::info!(
+                        "Exec enrollment: {} (inode={}) -> pod={}, role={}",
+                        enrollment.executable_path,
+                        inode,
+                        enrollment.pod_id,
+                        enrollment.role
+                    );
+                }
+            } else {
+                log::warn!(
+                    "Exec enrollment: {} not found, skipping",
+                    enrollment.executable_path
+                );
+            }
+        }
+    }
+
+    // Load cgroup enrollments
+    if let Some(map) = object.map("cgroup_enrollment") {
+        for enrollment in &policy.cgroup_enrollments {
+            if let Ok(metadata) = fs::metadata(&enrollment.cgroup_path) {
+                let cgroup_id = metadata.ino();
+                if let Some(role) = policy.get_role(&enrollment.role) {
+                    let key = cgroup_id.to_ne_bytes();
+                    let mut value = [0u8; 16];
+                    value[0..8].copy_from_slice(&enrollment.pod_id.to_ne_bytes());
+                    value[8..12].copy_from_slice(&role.id.0.to_ne_bytes());
+                    map.update(&key, &value, MapFlags::empty())?;
+                    log::info!(
+                        "Cgroup enrollment: {} (id={}) -> pod={}, role={}",
+                        enrollment.cgroup_path,
+                        cgroup_id,
+                        enrollment.pod_id,
+                        enrollment.role
+                    );
+                }
+            } else {
+                log::warn!(
+                    "Cgroup enrollment: {} not found, skipping",
+                    enrollment.cgroup_path
+                );
+            }
+        }
+    }
+
+    log::info!("BPF maps populated");
+    Ok(())
+}
+
+fn add_path_state(
+    map: &libbpf_rs::Map,
+    role_id: u32,
+    pattern: &str,
+    allowed: bool,
+) -> Result<()> {
+    let components: Vec<&str> = pattern
+        .split('/')
+        .filter(|s| !s.is_empty() && *s != "**")
+        .collect();
+
+    if components.is_empty() {
+        return Ok(());
+    }
+
+    let mut state: u32 = 0;
+
+    for (i, component) in components.iter().enumerate() {
+        let is_last = i == components.len() - 1;
+        let is_wildcard = *component == "*";
+        let component_hash = if is_wildcard {
+            0
+        } else {
+            djb2_hash_u32(component)
+        };
+
+        let mut key = [0u8; 12];
+        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
+        key[4..8].copy_from_slice(&state.to_ne_bytes());
+        key[8..12].copy_from_slice(&component_hash.to_ne_bytes());
+
+        let next_state = if is_last {
+            if allowed {
+                0xFFFFFFFE
+            } else {
+                0xFFFFFFFF
+            }
+        } else {
+            djb2_hash_u32(&format!("{}:{}", role_id, &components[..=i].join("/")))
+        };
+
+        let mut value = [0u8; 8];
+        value[0..4].copy_from_slice(&next_state.to_ne_bytes());
+        value[4] = if is_last { 1 } else { 0 };
+        value[5] = if allowed { 1 } else { 0 };
+        value[6] = if is_wildcard { 1 } else { 0 };
+        value[7] = 0;
+
+        map.update(&key, &value, MapFlags::empty())?;
+        state = next_state;
+    }
+
+    // Handle directory patterns (ending with /)
+    if pattern.ends_with('/') {
+        let mut key = [0u8; 12];
+        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
+        key[4..8].copy_from_slice(&state.to_ne_bytes());
+        key[8..12].copy_from_slice(&0u32.to_ne_bytes());
+
+        let terminal_state: u32 = if allowed { 0xFFFFFFFE } else { 0xFFFFFFFF };
+        let mut value = [0u8; 8];
+        value[0..4].copy_from_slice(&terminal_state.to_ne_bytes());
+        value[4] = 1;
+        value[5] = if allowed { 1 } else { 0 };
+        value[6] = 1;
+        value[7] = 0;
+
+        map.update(&key, &value, MapFlags::empty())?;
+    }
+
+    log::debug!(
+        "Path state: role={} pattern=\"{}\" -> {}",
+        role_id,
+        pattern,
+        if allowed { "ALLOW" } else { "DENY" }
+    );
+
+    Ok(())
+}
+
+fn pin_all(object: &mut Object, links: &mut [Link]) -> Result<()> {
+    log::info!("Pinning BPF programs and maps to {}...", BPF_PIN_PATH);
+
+    // Create pin directory
+    fs::create_dir_all(BPF_PIN_PATH).context("Failed to create BPF pin directory")?;
+
+    let maps_dir = format!("{}/maps", BPF_PIN_PATH);
+    let progs_dir = format!("{}/progs", BPF_PIN_PATH);
+    let links_dir = format!("{}/links", BPF_PIN_PATH);
+
+    fs::create_dir_all(&maps_dir)?;
+    fs::create_dir_all(&progs_dir)?;
+    fs::create_dir_all(&links_dir)?;
+
+    // Pin all maps
+    let map_names = [
+        "task_storage",
+        "pod_to_role",
+        "role_flags",
+        "pending_enrollments",
+        "network_rules",
+        "path_rules",
+        "path_states",
+        "inode_cache",
+        "cache_generation",
+        "exec_enrollment",
+        "cgroup_enrollment",
+        "audit_events",
+    ];
+
+    for name in &map_names {
+        if let Some(map) = object.map_mut(name) {
+            let pin_path = format!("{}/{}", maps_dir, name);
+            if let Err(e) = map.pin(&pin_path) {
+                log::warn!("Failed to pin map {}: {}", name, e);
+            } else {
+                log::info!("Pinned map: {}", name);
+            }
+        }
+    }
+
+    // Pin all programs
+    let prog_names = [
+        "task_alloc",
+        "file_open",
+        "socket_bind",
+        "socket_connect",
+        "bprm_check_security",
+        "path_rename",
+        "sb_mount",
+        "sb_umount",
+    ];
+
+    for name in &prog_names {
+        if let Some(prog) = object.prog_mut(name) {
+            let pin_path = format!("{}/{}", progs_dir, name);
+            if let Err(e) = prog.pin(&pin_path) {
+                log::warn!("Failed to pin program {}: {}", name, e);
+            } else {
+                log::info!("Pinned program: {}", name);
+            }
+        }
+    }
+
+    // Pin links to keep programs attached
+    for (i, link) in links.iter_mut().enumerate() {
+        let pin_path = format!("{}/link_{}", links_dir, i);
+        if let Err(e) = link.pin(&pin_path) {
+            log::warn!("Failed to pin link {}: {}", i, e);
+        } else {
+            log::info!("Pinned link: {}", i);
+        }
+    }
+
+    log::info!("All BPF objects pinned successfully");
+    Ok(())
+}
+
+fn djb2_hash_u32(s: &str) -> u32 {
+    let mut hash: u32 = 5381;
+    for c in s.bytes().take(32) {
+        hash = hash.wrapping_mul(33).wrapping_add(c as u32);
+    }
+    hash
+}
+
+fn flags_to_byte(flags: &bpfjailer_common::types::PolicyFlags) -> u8 {
+    let mut byte: u8 = 0;
+    if flags.allow_file_access {
+        byte |= 0x01;
+    }
+    if flags.allow_network {
+        byte |= 0x02;
+    }
+    if flags.allow_exec {
+        byte |= 0x04;
+    }
+    if flags.require_signed_binary {
+        byte |= 0x08;
+    }
+    if flags.allow_setuid {
+        byte |= 0x10;
+    }
+    if flags.allow_ptrace {
+        byte |= 0x20;
+    }
+    byte
+}

--- a/config/bpfjailer-bootstrap.service
+++ b/config/bpfjailer-bootstrap.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=BpfJailer Bootstrap (Daemonless Mode)
+Documentation=https://github.com/gen0sec/bpfjailer
+DefaultDependencies=no
+Before=basic.target
+After=local-fs.target
+ConditionPathExists=/etc/bpfjailer/policy.json
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/bpfjailer-bootstrap
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+NoNewPrivileges=no
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadOnlyPaths=/
+ReadWritePaths=/sys/fs/bpf
+
+[Install]
+WantedBy=sysinit.target

--- a/config/bpfjailer-daemon.service
+++ b/config/bpfjailer-daemon.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=BpfJailer Daemon (Standard Mode)
+Documentation=https://github.com/your-org/bpfjailer
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/bpfjailer-daemon
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+NoNewPrivileges=no
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadOnlyPaths=/
+ReadWritePaths=/sys/fs/bpf /run/bpfjailer
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Introduced a new `bpfjailer-bootstrap` component that allows loading and pinning BPF programs at early boot without a running daemon. 
- Updated `Cargo.toml` and `Cargo.lock` to include the new package, and enhanced the README.md to document the new installation mode and its features. 
- Added service configuration for the bootstrap mode.