### PR TITLE
Restore buildable state, add build + wellness CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    # Group patch/minor bumps so they land as one reviewable PR.
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+    # Major bumps of the BPF loader change the API surface and need a manual
+    # migration, so they should not be raised automatically.
+    ignore:
+      - dependency-name: "libbpf-rs"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install BPF build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang llvm libelf-dev pkg-config
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev pkg-config
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install BPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libelf-dev pkg-config
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # The BPF objects are built by bpfjailer-bpf/build.rs via clang and are
+      # loaded at runtime, so they must be built before the userspace crates.
+      - name: Build BPF programs
+        working-directory: bpfjailer-bpf
+        run: cargo build --release
+
+      - name: Build workspace
+        run: cargo build --release --workspace
+
+      - name: Verify artifacts exist
+        run: |
+          test -f target/release/bpfjailer-bootstrap
+          test -f target/release/bpfjailer-daemon
+          test -f bpfjailer-bpf/target/bpfel-unknown-none/release/bpfjailer.bpf.o
+
+  clippy:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install BPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libelf-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Build BPF programs
+        working-directory: bpfjailer-bpf
+        run: cargo build --release
+      - name: cargo fmt
+        run: cargo fmt --all --check
+        continue-on-error: true
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets
+        continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,25 +37,3 @@ jobs:
           test -f target/release/bpfjailer-bootstrap
           test -f target/release/bpfjailer-daemon
           test -f bpfjailer-bpf/target/bpfel-unknown-none/release/bpfjailer.bpf.o
-
-  clippy:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install BPF build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang llvm libelf-dev pkg-config
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - name: Build BPF programs
-        working-directory: bpfjailer-bpf
-        run: cargo build --release
-      - name: cargo fmt
-        run: cargo fmt --all --check
-        continue-on-error: true
-      - name: cargo clippy
-        run: cargo clippy --workspace --all-targets
-        continue-on-error: true

--- a/.github/workflows/wellness-check.yml
+++ b/.github/workflows/wellness-check.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install BPF build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang llvm libelf-dev pkg-config
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -65,7 +65,7 @@ jobs:
       - name: Install BPF build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang llvm libelf-dev pkg-config
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -81,7 +81,7 @@ jobs:
       - name: Install BPF build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang llvm libelf-dev pkg-config
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/wellness-check.yml
+++ b/.github/workflows/wellness-check.yml
@@ -1,0 +1,106 @@
+name: Wellness Check
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+# The BPF objects are produced by bpfjailer-bpf/build.rs via clang and are
+# loaded at runtime, so clang/llvm/libelf are needed by anything that touches
+# the workspace -- including `cargo clippy` and `cargo doc`.
+
+jobs:
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  machete:
+    name: Unused dependencies
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bnjbvr/cargo-machete@main
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install BPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libelf-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: clippy
+      - run: cargo clippy --locked --workspace --all-targets -- --deny warnings
+
+  doc:
+    name: Documentation
+    runs-on: ubuntu-24.04
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install BPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libelf-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: doc
+      - run: cargo doc --locked --workspace --no-deps
+
+  unit-tests:
+    name: Unit tests
+    needs: [fmt, clippy]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install BPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libelf-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: unit-tests
+      - run: cargo test --locked --workspace --lib
+
+  miri:
+    name: Miri (UB detector)
+    needs: [fmt, clippy]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-permissive-provenance
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      # Restricted to bpfjailer-common: the bootstrap/daemon crates wrap
+      # libbpf via FFI and load BPF objects, which miri cannot model.
+      # bpfjailer-common is pure-Rust policy and type definitions.
+      - run: cargo +nightly miri test -p bpfjailer-common --lib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,10 +132,7 @@ dependencies = [
  "bpfjailer-common",
  "env_logger",
  "libbpf-rs",
- "libbpf-sys",
- "libc",
  "log",
- "serde",
  "serde_json",
 ]
 
@@ -149,8 +146,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bpfjailer-common",
- "bytes",
- "nix 0.31.2",
  "serde",
  "serde_json",
  "tokio",
@@ -161,8 +156,6 @@ name = "bpfjailer-common"
 version = "0.1.0"
 dependencies = [
  "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -172,15 +165,10 @@ dependencies = [
  "anyhow",
  "bpfjailer-client",
  "bpfjailer-common",
- "bytes",
  "env_logger",
  "libbpf-rs",
- "libbpf-sys",
- "libc",
  "log",
- "nix 0.31.2",
  "ring",
- "serde",
  "serde_json",
  "tokio",
  "x509-parser",
@@ -485,18 +473,6 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -91,7 +91,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -103,7 +103,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -111,6 +111,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -156,7 +162,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -252,7 +258,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -279,13 +285,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -303,6 +315,28 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -338,7 +372,7 @@ checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -349,13 +383,18 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libbpf-rs"
-version = "0.26.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6af29f679fd713ba4466b0296436268f573f6c5a8ef2f316d237eb3019c3c6f"
+checksum = "d70f003d6e48e60a7ed55d4fb5b2419b91a962c903fa0b00e8db95a3b6651abc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+ "lazy_static",
  "libbpf-sys",
  "libc",
+ "nix 0.26.4",
+ "num_enum",
+ "strum_macros",
+ "thiserror 1.0.69",
  "vsprintf",
 ]
 
@@ -404,6 +443,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,11 +470,23 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -438,7 +498,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -489,6 +549,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +577,12 @@ checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -560,6 +647,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,7 +680,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -644,12 +741,18 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scopeguard"
@@ -684,7 +787,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -733,6 +836,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,7 +878,16 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -760,7 +896,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -771,7 +918,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -830,7 +977,24 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1030,6 +1194,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,7 +1215,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-libbpf-rs = "0.26"
+libbpf-rs = "0.21"
 libbpf-sys = "1.4"
 tokio = { version = "1.35", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/bpfjailer-bootstrap/Cargo.toml
+++ b/bpfjailer-bootstrap/Cargo.toml
@@ -11,10 +11,7 @@ path = "src/main.rs"
 [dependencies]
 bpfjailer-common = { path = "../bpfjailer-common" }
 libbpf-rs = "0.21"
-libbpf-sys = "1.4"
-serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
-libc = "0.2"

--- a/bpfjailer-bootstrap/Cargo.toml
+++ b/bpfjailer-bootstrap/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 bpfjailer-common = { path = "../bpfjailer-common" }
-libbpf-rs = "0.26"
+libbpf-rs = "0.21"
 libbpf-sys = "1.4"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -302,7 +302,7 @@ fn add_path_state(map: &libbpf_rs::Map, role_id: u32, pattern: &str, allowed: bo
                 0xFFFFFFFF
             }
         } else {
-            djb2_hash_u32(&format!("{}:{}", role_id, &components[..=i].join("/")))
+            djb2_hash_u32(&format!("{}:{}", role_id, components[..=i].join("/")))
         };
 
         let mut value = [0u8; 8];

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -269,12 +269,7 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
     Ok(())
 }
 
-fn add_path_state(
-    map: &libbpf_rs::Map,
-    role_id: u32,
-    pattern: &str,
-    allowed: bool,
-) -> Result<()> {
+fn add_path_state(map: &libbpf_rs::Map, role_id: u32, pattern: &str, allowed: bool) -> Result<()> {
     let components: Vec<&str> = pattern
         .split('/')
         .filter(|s| !s.is_empty() && *s != "**")

--- a/bpfjailer-bpf/build.rs
+++ b/bpfjailer-bpf/build.rs
@@ -58,23 +58,30 @@ fn compile_bpf_program(src: &str, output: &str) {
     }
 
     args.extend_from_slice(&[
-        "-O2".to_string(), "-g".to_string(),
-        "-target".to_string(), "bpfel-unknown-none".to_string(),
-        "-c".to_string(), src.to_string(),
-        "-o".to_string(), output.to_string(),
+        "-O2".to_string(),
+        "-g".to_string(),
+        "-target".to_string(),
+        "bpfel-unknown-none".to_string(),
+        "-c".to_string(),
+        src.to_string(),
+        "-o".to_string(),
+        output.to_string(),
         "-Wno-unknown-attributes".to_string(),
         "-Wno-address-of-packed-member".to_string(),
         "-Wno-unused-value".to_string(),
         "-Wno-pointer-sign".to_string(),
         // Enable BTF for task_storage maps
-        "-g".to_string(),  // Already have this, but ensure it's there for BTF
+        "-g".to_string(), // Already have this, but ensure it's there for BTF
     ]);
 
     cmd.args(&args);
 
     let output_cmd = cmd.output().expect("Failed to execute clang");
     if !output_cmd.status.success() {
-        eprintln!("Clang stderr: {}", String::from_utf8_lossy(&output_cmd.stderr));
+        eprintln!(
+            "Clang stderr: {}",
+            String::from_utf8_lossy(&output_cmd.stderr)
+        );
         eprintln!("Clang command: clang {}", args.join(" "));
         panic!("Failed to compile BPF program: {}", src);
     }

--- a/bpfjailer-client/Cargo.toml
+++ b/bpfjailer-client/Cargo.toml
@@ -9,5 +9,3 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-bytes = { workspace = true }
-nix = { workspace = true }

--- a/bpfjailer-client/src/enrollment.rs
+++ b/bpfjailer-client/src/enrollment.rs
@@ -47,14 +47,8 @@ pub enum EnrollmentRequest {
 pub enum EnrollmentResponse {
     Success,
     Error(String),
-    ProcessInfo {
-        pod_id: PodId,
-        role_id: RoleId,
-    },
-    XattrInfo {
-        pod_id: PodId,
-        role_id: RoleId,
-    },
+    ProcessInfo { pod_id: PodId, role_id: RoleId },
+    XattrInfo { pod_id: PodId, role_id: RoleId },
 }
 
 pub struct EnrollmentClient {
@@ -83,8 +77,8 @@ impl EnrollmentClient {
         let mut response_buf = Vec::new();
         stream.read_to_end(&mut response_buf).await?;
 
-        let response: EnrollmentResponse = serde_json::from_slice(&response_buf)
-            .context("Failed to parse enrollment response")?;
+        let response: EnrollmentResponse =
+            serde_json::from_slice(&response_buf).context("Failed to parse enrollment response")?;
 
         match response {
             EnrollmentResponse::Success => Ok(()),
@@ -108,8 +102,8 @@ impl EnrollmentClient {
         let mut response_buf = Vec::new();
         stream.read_to_end(&mut response_buf).await?;
 
-        let response: EnrollmentResponse = serde_json::from_slice(&response_buf)
-            .context("Failed to parse query response")?;
+        let response: EnrollmentResponse =
+            serde_json::from_slice(&response_buf).context("Failed to parse query response")?;
 
         match response {
             EnrollmentResponse::ProcessInfo { pod_id, role_id } => Ok((pod_id, role_id)),

--- a/bpfjailer-common/Cargo.toml
+++ b/bpfjailer-common/Cargo.toml
@@ -5,5 +5,3 @@ edition = "2021"
 
 [dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
-thiserror = { workspace = true }

--- a/bpfjailer-common/src/policy.rs
+++ b/bpfjailer-common/src/policy.rs
@@ -114,6 +114,12 @@ pub struct PolicyConfig {
     pub cgroup_enrollments: Vec<CgroupEnrollment>,
 }
 
+impl Default for PolicyConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PolicyConfig {
     pub fn new() -> Self {
         Self {

--- a/bpfjailer-common/src/policy.rs
+++ b/bpfjailer-common/src/policy.rs
@@ -1,6 +1,6 @@
+use crate::types::{PolicyFlags, RoleId};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::types::{RoleId, PolicyFlags};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PathPattern {
@@ -151,72 +151,125 @@ impl SecretPatterns {
     pub fn all() -> Vec<PathPattern> {
         vec![
             // Environment variables (API keys, tokens)
-            PathPattern { pattern: "/proc/".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/proc/".to_string(),
+                allow: false,
+            },
             // SSH keys
-            PathPattern { pattern: "/.ssh/".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.ssh/".to_string(),
+                allow: false,
+            },
             // AWS credentials
-            PathPattern { pattern: "/.aws/".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.aws/".to_string(),
+                allow: false,
+            },
             // Google Cloud credentials
-            PathPattern { pattern: "/.config/gcloud/".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.config/gcloud/".to_string(),
+                allow: false,
+            },
             // Azure credentials
-            PathPattern { pattern: "/.azure/".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.azure/".to_string(),
+                allow: false,
+            },
             // Kubernetes config
-            PathPattern { pattern: "/.kube/".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.kube/".to_string(),
+                allow: false,
+            },
             // Docker config (contains registry credentials)
-            PathPattern { pattern: "/.docker/".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.docker/".to_string(),
+                allow: false,
+            },
             // System password files
-            PathPattern { pattern: "/etc/shadow".to_string(), allow: false },
-            PathPattern { pattern: "/etc/gshadow".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/etc/shadow".to_string(),
+                allow: false,
+            },
+            PathPattern {
+                pattern: "/etc/gshadow".to_string(),
+                allow: false,
+            },
             // Common private key locations
-            PathPattern { pattern: "/etc/ssl/private/".to_string(), allow: false },
-            PathPattern { pattern: "/etc/pki/".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/etc/ssl/private/".to_string(),
+                allow: false,
+            },
+            PathPattern {
+                pattern: "/etc/pki/".to_string(),
+                allow: false,
+            },
             // npm/yarn tokens
-            PathPattern { pattern: "/.npmrc".to_string(), allow: false },
-            PathPattern { pattern: "/.yarnrc".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.npmrc".to_string(),
+                allow: false,
+            },
+            PathPattern {
+                pattern: "/.yarnrc".to_string(),
+                allow: false,
+            },
             // Git credentials
-            PathPattern { pattern: "/.git-credentials".to_string(), allow: false },
-            PathPattern { pattern: "/.netrc".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.git-credentials".to_string(),
+                allow: false,
+            },
+            PathPattern {
+                pattern: "/.netrc".to_string(),
+                allow: false,
+            },
             // Python/pip
-            PathPattern { pattern: "/.pypirc".to_string(), allow: false },
-
+            PathPattern {
+                pattern: "/.pypirc".to_string(),
+                allow: false,
+            },
             // GPG keys
-            PathPattern { pattern: "/.gnupg/".to_string(), allow: false },
+            PathPattern {
+                pattern: "/.gnupg/".to_string(),
+                allow: false,
+            },
         ]
     }
 
     /// Get patterns for SSH key protection only
     pub fn ssh_keys() -> Vec<PathPattern> {
-        vec![
-            PathPattern { pattern: "/.ssh/".to_string(), allow: false },
-        ]
+        vec![PathPattern {
+            pattern: "/.ssh/".to_string(),
+            allow: false,
+        }]
     }
 
     /// Get patterns for cloud credentials protection
     pub fn cloud_credentials() -> Vec<PathPattern> {
         vec![
-            PathPattern { pattern: "/.aws/".to_string(), allow: false },
-            PathPattern { pattern: "/.config/gcloud/".to_string(), allow: false },
-            PathPattern { pattern: "/.azure/".to_string(), allow: false },
-            PathPattern { pattern: "/.kube/".to_string(), allow: false },
+            PathPattern {
+                pattern: "/.aws/".to_string(),
+                allow: false,
+            },
+            PathPattern {
+                pattern: "/.config/gcloud/".to_string(),
+                allow: false,
+            },
+            PathPattern {
+                pattern: "/.azure/".to_string(),
+                allow: false,
+            },
+            PathPattern {
+                pattern: "/.kube/".to_string(),
+                allow: false,
+            },
         ]
     }
 
     /// Get patterns for environment/process information protection
     pub fn process_info() -> Vec<PathPattern> {
-        vec![
-            PathPattern { pattern: "/proc/".to_string(), allow: false },
-        ]
+        vec![PathPattern {
+            pattern: "/proc/".to_string(),
+            allow: false,
+        }]
     }
 }
 
@@ -226,23 +279,31 @@ pub struct AllowedDomains;
 impl AllowedDomains {
     /// OpenAI API endpoints
     pub fn openai() -> Vec<DomainRule> {
-        vec![
-            DomainRule { domain: "api.openai.com".to_string(), allow: true },
-        ]
+        vec![DomainRule {
+            domain: "api.openai.com".to_string(),
+            allow: true,
+        }]
     }
 
     /// Anthropic API endpoints
     pub fn anthropic() -> Vec<DomainRule> {
-        vec![
-            DomainRule { domain: "api.anthropic.com".to_string(), allow: true },
-        ]
+        vec![DomainRule {
+            domain: "api.anthropic.com".to_string(),
+            allow: true,
+        }]
     }
 
     /// Google AI endpoints
     pub fn google_ai() -> Vec<DomainRule> {
         vec![
-            DomainRule { domain: "generativelanguage.googleapis.com".to_string(), allow: true },
-            DomainRule { domain: "aiplatform.googleapis.com".to_string(), allow: true },
+            DomainRule {
+                domain: "generativelanguage.googleapis.com".to_string(),
+                allow: true,
+            },
+            DomainRule {
+                domain: "aiplatform.googleapis.com".to_string(),
+                allow: true,
+            },
         ]
     }
 
@@ -252,8 +313,14 @@ impl AllowedDomains {
         rules.extend(Self::openai());
         rules.extend(Self::anthropic());
         rules.extend(Self::google_ai());
-        rules.push(DomainRule { domain: "api.cohere.ai".to_string(), allow: true });
-        rules.push(DomainRule { domain: "api.mistral.ai".to_string(), allow: true });
+        rules.push(DomainRule {
+            domain: "api.cohere.ai".to_string(),
+            allow: true,
+        });
+        rules.push(DomainRule {
+            domain: "api.mistral.ai".to_string(),
+            allow: true,
+        });
         rules
     }
 }

--- a/bpfjailer-common/src/types.rs
+++ b/bpfjailer-common/src/types.rs
@@ -30,4 +30,3 @@ pub struct PolicyFlags {
     #[serde(default)]
     pub require_proxy: bool,
 }
-

--- a/bpfjailer-common/src/types.rs
+++ b/bpfjailer-common/src/types.rs
@@ -14,7 +14,7 @@ pub struct ProcessInfo {
     pub stack_depth: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PolicyFlags {
     pub allow_file_access: bool,
     pub allow_network: bool,
@@ -31,18 +31,3 @@ pub struct PolicyFlags {
     pub require_proxy: bool,
 }
 
-impl Default for PolicyFlags {
-    fn default() -> Self {
-        Self {
-            allow_file_access: false,
-            allow_network: false,
-            allow_exec: false,
-            require_signed_binary: false,
-            allow_setuid: false,
-            allow_ptrace: false,
-            allow_module_load: false,
-            allow_bpf_load: false,
-            require_proxy: false,
-        }
-    }
-}

--- a/bpfjailer-daemon/Cargo.toml
+++ b/bpfjailer-daemon/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 bpfjailer-common = { path = "../bpfjailer-common" }
 bpfjailer-client = { path = "../bpfjailer-client" }
-libbpf-rs = "0.26"
+libbpf-rs = "0.21"
 libbpf-sys = "1.4"
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/bpfjailer-daemon/Cargo.toml
+++ b/bpfjailer-daemon/Cargo.toml
@@ -11,16 +11,17 @@ path = "src/main.rs"
 bpfjailer-common = { path = "../bpfjailer-common" }
 bpfjailer-client = { path = "../bpfjailer-client" }
 libbpf-rs = "0.21"
-libbpf-sys = "1.4"
 tokio = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-nix = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
-bytes = { workspace = true }
 x509-parser = "0.18"
 ring = "0.17"
 xattr = "1.3"
-libc = "0.2"
+
+# ring and x509-parser back the signature-validation path stubbed out in
+# src/signed_binary.rs (README lists Signed Binaries as planned). They are
+# declared ahead of that work rather than removed and re-added.
+[package.metadata.cargo-machete]
+ignored = ["ring", "x509-parser"]

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -37,7 +37,8 @@ impl BpfJailerBpf {
             PathBuf::from("bpfjailer-bpf/target/bpfel-unknown-none/debug/bpfjailer.bpf.o"),
         ];
 
-        let obj_path = possible_paths.iter()
+        let obj_path = possible_paths
+            .iter()
             .find(|p| p.exists())
             .ok_or_else(|| anyhow::anyhow!("bpfjailer.bpf.o not found in any expected location"))?;
 
@@ -56,14 +57,20 @@ impl BpfJailerBpf {
                 if err_str.contains("task_storage") || err_str.contains("EINVAL") {
                     log::error!("Failed to load BPF object - task_storage map creation failed");
                     log::error!("This may be a kernel issue. Error: {}", err_str);
-                    log::error!("Kernel version: {}", std::process::Command::new("uname")
-                        .arg("-r")
-                        .output()
-                        .ok()
-                        .and_then(|o| String::from_utf8(o.stdout).ok())
-                        .unwrap_or_else(|| "unknown".to_string()));
-                    log::error!("BPF LSM status: {}", std::fs::read_to_string("/sys/kernel/security/lsm")
-                        .unwrap_or_else(|_| "unknown".to_string()));
+                    log::error!(
+                        "Kernel version: {}",
+                        std::process::Command::new("uname")
+                            .arg("-r")
+                            .output()
+                            .ok()
+                            .and_then(|o| String::from_utf8(o.stdout).ok())
+                            .unwrap_or_else(|| "unknown".to_string())
+                    );
+                    log::error!(
+                        "BPF LSM status: {}",
+                        std::fs::read_to_string("/sys/kernel/security/lsm")
+                            .unwrap_or_else(|_| "unknown".to_string())
+                    );
                 }
                 return Err(anyhow::Error::from(e));
             }
@@ -185,7 +192,8 @@ impl BpfJailerBpf {
 
     pub fn update_pod_role(&self, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("pod_to_role")
+        let map = object
+            .map("pod_to_role")
             .ok_or_else(|| anyhow::anyhow!("pod_to_role map not found"))?;
         let key = pod_id.to_ne_bytes();
         let value = role_id.to_ne_bytes();
@@ -195,7 +203,8 @@ impl BpfJailerBpf {
 
     pub fn update_role_flags(&self, role_id: u32, flags: u8) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("role_flags")
+        let map = object
+            .map("role_flags")
             .ok_or_else(|| anyhow::anyhow!("role_flags map not found"))?;
         let key = role_id.to_ne_bytes();
         let value = [flags];
@@ -207,7 +216,8 @@ impl BpfJailerBpf {
     /// on the next syscall (file_open, exec, etc.)
     pub fn enroll_pending_process(&self, pid: u32, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("pending_enrollments")
+        let map = object
+            .map("pending_enrollments")
             .ok_or_else(|| anyhow::anyhow!("pending_enrollments map not found"))?;
 
         let key = pid.to_ne_bytes();
@@ -221,7 +231,12 @@ impl BpfJailerBpf {
         value[13] = 0; // flags
 
         map.update(&key, &value, MapFlags::empty())?;
-        log::debug!("Added pending enrollment for PID {} -> pod_id={}, role_id={}", pid, pod_id, role_id);
+        log::debug!(
+            "Added pending enrollment for PID {} -> pod_id={}, role_id={}",
+            pid,
+            pod_id,
+            role_id
+        );
         Ok(())
     }
 
@@ -229,9 +244,17 @@ impl BpfJailerBpf {
     /// protocol: 6 = TCP, 17 = UDP
     /// direction: 0 = bind, 1 = connect
     /// allowed: true = allow, false = deny
-    pub fn add_network_rule(&self, role_id: u32, port: u16, protocol: u8, direction: u8, allowed: bool) -> Result<()> {
+    pub fn add_network_rule(
+        &self,
+        role_id: u32,
+        port: u16,
+        protocol: u8,
+        direction: u8,
+        allowed: bool,
+    ) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("network_rules")
+        let map = object
+            .map("network_rules")
             .ok_or_else(|| anyhow::anyhow!("network_rules map not found"))?;
 
         // struct net_rule_key { u32 role_id; u16 port; u8 protocol; u8 direction; }
@@ -251,16 +274,30 @@ impl BpfJailerBpf {
         };
         let dir_name = if direction == 0 { "bind" } else { "connect" };
         let action = if allowed { "ALLOW" } else { "DENY" };
-        log::info!("Network rule: role={} {}:{} {} -> {}", role_id, proto_name, port, dir_name, action);
+        log::info!(
+            "Network rule: role={} {}:{} {} -> {}",
+            role_id,
+            proto_name,
+            port,
+            dir_name,
+            action
+        );
 
         Ok(())
     }
 
     /// Remove a network rule
     #[allow(dead_code)]
-    pub fn remove_network_rule(&self, role_id: u32, port: u16, protocol: u8, direction: u8) -> Result<()> {
+    pub fn remove_network_rule(
+        &self,
+        role_id: u32,
+        port: u16,
+        protocol: u8,
+        direction: u8,
+    ) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("network_rules")
+        let map = object
+            .map("network_rules")
             .ok_or_else(|| anyhow::anyhow!("network_rules map not found"))?;
 
         let mut key = [0u8; 8];
@@ -278,13 +315,14 @@ impl BpfJailerBpf {
     /// allowed: true = allow, false = deny
     pub fn add_path_rule(&self, role_id: u32, path: &str, allowed: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("path_rules")
+        let map = object
+            .map("path_rules")
             .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
 
         let path_hash = djb2_hash(path);
 
         // struct path_rule_key { u32 role_id; u64 path_hash; }
-        let mut key = [0u8; 16];  // 4 + 4 padding + 8 = 16 bytes
+        let mut key = [0u8; 16]; // 4 + 4 padding + 8 = 16 bytes
         key[0..4].copy_from_slice(&role_id.to_ne_bytes());
         // padding bytes 4-7 are zero
         key[8..16].copy_from_slice(&path_hash.to_ne_bytes());
@@ -293,7 +331,13 @@ impl BpfJailerBpf {
         map.update(&key, &value, MapFlags::empty())?;
 
         let action = if allowed { "ALLOW" } else { "DENY" };
-        log::info!("Path rule: role={} path=\"{}\" (hash={:#x}) -> {}", role_id, path, path_hash, action);
+        log::info!(
+            "Path rule: role={} path=\"{}\" (hash={:#x}) -> {}",
+            role_id,
+            path,
+            path_hash,
+            action
+        );
 
         Ok(())
     }
@@ -302,7 +346,8 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_path_rule(&self, role_id: u32, path: &str) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("path_rules")
+        let map = object
+            .map("path_rules")
             .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
 
         let path_hash = djb2_hash(path);
@@ -323,7 +368,8 @@ impl BpfJailerBpf {
     ///   - Wildcards: "/var/lib/*/data" (* matches any single component)
     pub fn add_path_state(&self, role_id: u32, pattern: &str, allowed: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("path_states")
+        let map = object
+            .map("path_states")
             .ok_or_else(|| anyhow::anyhow!("path_states map not found"))?;
 
         // Parse path into components
@@ -336,12 +382,16 @@ impl BpfJailerBpf {
             return Ok(());
         }
 
-        let mut state: u32 = 0;  // Start from root state
+        let mut state: u32 = 0; // Start from root state
 
         for (i, component) in components.iter().enumerate() {
             let is_last = i == components.len() - 1;
             let is_wildcard = *component == "*";
-            let component_hash = if is_wildcard { 0 } else { djb2_hash_u32(component) };
+            let component_hash = if is_wildcard {
+                0
+            } else {
+                djb2_hash_u32(component)
+            };
 
             // Create state transition
             // struct path_state_key { u32 role_id; u32 state; u32 component_hash; }
@@ -351,7 +401,11 @@ impl BpfJailerBpf {
             key[8..12].copy_from_slice(&component_hash.to_ne_bytes());
 
             let next_state = if is_last {
-                if allowed { 0xFFFFFFFE } else { 0xFFFFFFFF }  // ACCEPT or REJECT
+                if allowed {
+                    0xFFFFFFFE
+                } else {
+                    0xFFFFFFFF
+                } // ACCEPT or REJECT
             } else {
                 // Generate unique state ID based on path so far
                 djb2_hash_u32(&format!("{}:{}", role_id, &components[..=i].join("/")))
@@ -360,10 +414,10 @@ impl BpfJailerBpf {
             // struct path_state_value { u32 next_state; u8 is_terminal; u8 decision; u8 wildcard; u8 _pad; }
             let mut value = [0u8; 8];
             value[0..4].copy_from_slice(&next_state.to_ne_bytes());
-            value[4] = if is_last { 1 } else { 0 };  // is_terminal
-            value[5] = if allowed { 1 } else { 0 };  // decision
-            value[6] = if is_wildcard { 1 } else { 0 };  // wildcard
-            value[7] = 0;  // padding
+            value[4] = if is_last { 1 } else { 0 }; // is_terminal
+            value[5] = if allowed { 1 } else { 0 }; // decision
+            value[6] = if is_wildcard { 1 } else { 0 }; // wildcard
+            value[7] = 0; // padding
 
             map.update(&key, &value, MapFlags::empty())?;
 
@@ -376,22 +430,27 @@ impl BpfJailerBpf {
             let mut key = [0u8; 12];
             key[0..4].copy_from_slice(&role_id.to_ne_bytes());
             key[4..8].copy_from_slice(&state.to_ne_bytes());
-            key[8..12].copy_from_slice(&0u32.to_ne_bytes());  // wildcard (0 = any)
+            key[8..12].copy_from_slice(&0u32.to_ne_bytes()); // wildcard (0 = any)
 
             let terminal_state: u32 = if allowed { 0xFFFFFFFE } else { 0xFFFFFFFF };
             let mut value = [0u8; 8];
             value[0..4].copy_from_slice(&terminal_state.to_ne_bytes());
-            value[4] = 1;  // is_terminal
+            value[4] = 1; // is_terminal
             value[5] = if allowed { 1 } else { 0 };
-            value[6] = 1;  // wildcard
+            value[6] = 1; // wildcard
             value[7] = 0;
 
             map.update(&key, &value, MapFlags::empty())?;
         }
 
         let action = if allowed { "ALLOW" } else { "DENY" };
-        log::info!("Path state: role={} pattern=\"{}\" -> {} ({} components)",
-                   role_id, pattern, action, components.len());
+        log::info!(
+            "Path state: role={} pattern=\"{}\" -> {} ({} components)",
+            role_id,
+            pattern,
+            action,
+            components.len()
+        );
 
         // Debug: show component hashes
         for (i, comp) in components.iter().enumerate() {
@@ -405,22 +464,31 @@ impl BpfJailerBpf {
     /// Increment cache generation counter to invalidate inode cache
     pub fn invalidate_cache(&self) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("cache_generation")
+        let map = object
+            .map("cache_generation")
             .ok_or_else(|| anyhow::anyhow!("cache_generation map not found"))?;
 
         // Read current generation
         let key = 0u32.to_ne_bytes();
-        let current_gen = map.lookup(&key, MapFlags::empty())?
+        let current_gen = map
+            .lookup(&key, MapFlags::empty())?
             .ok_or_else(|| anyhow::anyhow!("cache_generation map entry not found"))?;
 
         // Increment it (wrapping is fine)
         let current: u32 = u32::from_ne_bytes([
-            current_gen[0], current_gen[1], current_gen[2], current_gen[3]
+            current_gen[0],
+            current_gen[1],
+            current_gen[2],
+            current_gen[3],
         ]);
         let new_gen = current.wrapping_add(1);
 
         map.update(&key, &new_gen.to_ne_bytes(), MapFlags::empty())?;
-        log::info!("Invalidated inode cache (generation: {} -> {})", current, new_gen);
+        log::info!(
+            "Invalidated inode cache (generation: {} -> {})",
+            current,
+            new_gen
+        );
         Ok(())
     }
 
@@ -428,7 +496,8 @@ impl BpfJailerBpf {
     /// All processes executing this binary will be auto-enrolled
     pub fn add_exec_enrollment(&self, inode: u64, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("exec_enrollment")
+        let map = object
+            .map("exec_enrollment")
             .ok_or_else(|| anyhow::anyhow!("exec_enrollment map not found"))?;
 
         let key = inode.to_ne_bytes();
@@ -439,7 +508,12 @@ impl BpfJailerBpf {
         value[8..12].copy_from_slice(&role_id.to_ne_bytes());
 
         map.update(&key, &value, MapFlags::empty())?;
-        log::info!("Exec enrollment: inode={} -> pod_id={}, role_id={}", inode, pod_id, role_id);
+        log::info!(
+            "Exec enrollment: inode={} -> pod_id={}, role_id={}",
+            inode,
+            pod_id,
+            role_id
+        );
         Ok(())
     }
 
@@ -447,7 +521,8 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_exec_enrollment(&self, inode: u64) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("exec_enrollment")
+        let map = object
+            .map("exec_enrollment")
             .ok_or_else(|| anyhow::anyhow!("exec_enrollment map not found"))?;
 
         let key = inode.to_ne_bytes();
@@ -460,7 +535,8 @@ impl BpfJailerBpf {
     /// All processes in this cgroup will be auto-enrolled
     pub fn add_cgroup_enrollment(&self, cgroup_id: u64, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("cgroup_enrollment")
+        let map = object
+            .map("cgroup_enrollment")
             .ok_or_else(|| anyhow::anyhow!("cgroup_enrollment map not found"))?;
 
         let key = cgroup_id.to_ne_bytes();
@@ -471,7 +547,12 @@ impl BpfJailerBpf {
         value[8..12].copy_from_slice(&role_id.to_ne_bytes());
 
         map.update(&key, &value, MapFlags::empty())?;
-        log::info!("Cgroup enrollment: cgroup_id={} -> pod_id={}, role_id={}", cgroup_id, pod_id, role_id);
+        log::info!(
+            "Cgroup enrollment: cgroup_id={} -> pod_id={}, role_id={}",
+            cgroup_id,
+            pod_id,
+            role_id
+        );
         Ok(())
     }
 
@@ -479,7 +560,8 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_cgroup_enrollment(&self, cgroup_id: u64) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("cgroup_enrollment")
+        let map = object
+            .map("cgroup_enrollment")
             .ok_or_else(|| anyhow::anyhow!("cgroup_enrollment map not found"))?;
 
         let key = cgroup_id.to_ne_bytes();
@@ -496,23 +578,32 @@ impl BpfJailerBpf {
     /// cidr: IP address or CIDR notation (e.g., "10.0.0.0/8", "192.168.1.1")
     /// direction: 0 = bind, 1 = connect
     /// allowed: true = allow, false = deny
-    pub fn add_ip_rule(&self, role_id: u32, cidr: &str, direction: u8, allowed: bool) -> Result<()> {
+    pub fn add_ip_rule(
+        &self,
+        role_id: u32,
+        cidr: &str,
+        direction: u8,
+        allowed: bool,
+    ) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("ip_rules")
+        let map = object
+            .map("ip_rules")
             .ok_or_else(|| anyhow::anyhow!("ip_rules map not found"))?;
 
         // Parse CIDR notation
         let (ip_str, prefix_len) = if let Some(slash_pos) = cidr.find('/') {
             let (ip, prefix) = cidr.split_at(slash_pos);
-            let prefix_len: u8 = prefix[1..].parse()
+            let prefix_len: u8 = prefix[1..]
+                .parse()
                 .map_err(|_| anyhow::anyhow!("Invalid prefix length in CIDR: {}", cidr))?;
             (ip, prefix_len)
         } else {
-            (cidr, 32u8)  // Single IP = /32
+            (cidr, 32u8) // Single IP = /32
         };
 
         // Parse IP address
-        let ip_addr: std::net::Ipv4Addr = ip_str.parse()
+        let ip_addr: std::net::Ipv4Addr = ip_str
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid IPv4 address: {}", ip_str))?;
         let ip_bytes = ip_addr.octets();
 
@@ -546,7 +637,13 @@ impl BpfJailerBpf {
 
         let dir_name = if direction == 0 { "bind" } else { "connect" };
         let action = if allowed { "ALLOW" } else { "DENY" };
-        log::info!("IP rule: role={} {} {} -> {}", role_id, cidr, dir_name, action);
+        log::info!(
+            "IP rule: role={} {} {} -> {}",
+            role_id,
+            cidr,
+            dir_name,
+            action
+        );
 
         Ok(())
     }
@@ -555,7 +652,8 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_ip_rule(&self, role_id: u32, cidr: &str, direction: u8) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("ip_rules")
+        let map = object
+            .map("ip_rules")
             .ok_or_else(|| anyhow::anyhow!("ip_rules map not found"))?;
 
         let (ip_str, prefix_len) = if let Some(slash_pos) = cidr.find('/') {
@@ -593,18 +691,24 @@ impl BpfJailerBpf {
     /// required: if true, all connections must go through the proxy
     pub fn set_proxy_config(&self, role_id: u32, proxy_addr: &str, required: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("proxy_config")
+        let map = object
+            .map("proxy_config")
             .ok_or_else(|| anyhow::anyhow!("proxy_config map not found"))?;
 
         // Parse proxy address
         let parts: Vec<&str> = proxy_addr.split(':').collect();
         if parts.len() != 2 {
-            return Err(anyhow::anyhow!("Invalid proxy address format: {}", proxy_addr));
+            return Err(anyhow::anyhow!(
+                "Invalid proxy address format: {}",
+                proxy_addr
+            ));
         }
 
-        let proxy_ip: std::net::Ipv4Addr = parts[0].parse()
+        let proxy_ip: std::net::Ipv4Addr = parts[0]
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid proxy IP: {}", parts[0]))?;
-        let proxy_port: u16 = parts[1].parse()
+        let proxy_port: u16 = parts[1]
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid proxy port: {}", parts[1]))?;
 
         let ip_bytes = proxy_ip.octets();
@@ -630,7 +734,8 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_proxy_config(&self, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("proxy_config")
+        let map = object
+            .map("proxy_config")
             .ok_or_else(|| anyhow::anyhow!("proxy_config map not found"))?;
 
         let key = role_id.to_ne_bytes();
@@ -644,7 +749,8 @@ impl BpfJailerBpf {
     /// allowed: true = allow, false = deny
     pub fn add_domain_rule(&self, role_id: u32, domain: &str, allowed: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("domain_rules")
+        let map = object
+            .map("domain_rules")
             .ok_or_else(|| anyhow::anyhow!("domain_rules map not found"))?;
 
         let domain_hash = djb2_hash_u32(domain);
@@ -658,7 +764,13 @@ impl BpfJailerBpf {
         map.update(&key, &value, MapFlags::empty())?;
 
         let action = if allowed { "ALLOW" } else { "DENY" };
-        log::info!("Domain rule: role={} {} (hash={:#x}) -> {}", role_id, domain, domain_hash, action);
+        log::info!(
+            "Domain rule: role={} {} (hash={:#x}) -> {}",
+            role_id,
+            domain,
+            domain_hash,
+            action
+        );
 
         Ok(())
     }
@@ -667,7 +779,8 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_domain_rule(&self, role_id: u32, domain: &str) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object.map("domain_rules")
+        let map = object
+            .map("domain_rules")
             .ok_or_else(|| anyhow::anyhow!("domain_rules map not found"))?;
 
         let domain_hash = djb2_hash_u32(domain);
@@ -728,9 +841,18 @@ impl BpfJailerBpf {
 
         // Pin maps
         let map_names = [
-            "task_storage", "pod_to_role", "role_flags", "pending_enrollments",
-            "network_rules", "path_rules", "path_states", "inode_cache",
-            "cache_generation", "exec_enrollment", "cgroup_enrollment", "audit_events",
+            "task_storage",
+            "pod_to_role",
+            "role_flags",
+            "pending_enrollments",
+            "network_rules",
+            "path_rules",
+            "path_states",
+            "inode_cache",
+            "cache_generation",
+            "exec_enrollment",
+            "cgroup_enrollment",
+            "audit_events",
         ];
 
         for name in &map_names {
@@ -762,12 +884,18 @@ impl BpfJailerBpf {
             ));
         }
 
-        log::info!("Connecting to pinned BPF objects at {}...", Self::BPF_PIN_PATH);
+        log::info!(
+            "Connecting to pinned BPF objects at {}...",
+            Self::BPF_PIN_PATH
+        );
 
         // For the logging daemon, we just need access to the audit_events map
         let audit_map_path = format!("{}/maps/audit_events", Self::BPF_PIN_PATH);
         if !std::path::Path::new(&audit_map_path).exists() {
-            return Err(anyhow::anyhow!("audit_events map not found at {}", audit_map_path));
+            return Err(anyhow::anyhow!(
+                "audit_events map not found at {}",
+                audit_map_path
+            ));
         }
 
         // Open the pinned map

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -175,6 +175,10 @@ impl BpfJailerBpf {
         log::info!("All eBPF programs loaded and attached successfully");
 
         Ok(Self {
+            // libbpf_rs::Object is neither Send nor Sync; the Arc<Mutex<_>>
+            // is only shared within a single thread here. Worth revisiting if
+            // the loader ever becomes multi-threaded.
+            #[allow(clippy::arc_with_non_send_sync)]
             object: Arc::new(Mutex::new(object)),
         })
     }

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -408,7 +408,7 @@ impl BpfJailerBpf {
                 } // ACCEPT or REJECT
             } else {
                 // Generate unique state ID based on path so far
-                djb2_hash_u32(&format!("{}:{}", role_id, &components[..=i].join("/")))
+                djb2_hash_u32(&format!("{}:{}", role_id, components[..=i].join("/")))
             };
 
             // struct path_state_value { u32 next_state; u8 is_terminal; u8 decision; u8 wildcard; u8 _pad; }

--- a/bpfjailer-daemon/src/enrollment.rs
+++ b/bpfjailer-daemon/src/enrollment.rs
@@ -1,3 +1,6 @@
+use crate::enrollment_alternatives::AlternativeEnrollment;
+use crate::policy::PolicyManager;
+use crate::process_tracker::ProcessTracker;
 use anyhow::{Context, Result};
 use bpfjailer_client::{EnrollmentRequest, EnrollmentResponse};
 use log::{debug, error, info};
@@ -6,9 +9,6 @@ use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener as AsyncUnixListener, UnixStream as AsyncUnixStream};
 use tokio::sync::RwLock;
-use crate::process_tracker::ProcessTracker;
-use crate::policy::PolicyManager;
-use crate::enrollment_alternatives::AlternativeEnrollment;
 
 const SOCKET_PATH: &str = "/run/bpfjailer/enrollment.sock";
 
@@ -40,8 +40,8 @@ impl EnrollmentServer {
             std::fs::create_dir_all(parent)?;
         }
 
-        let listener = AsyncUnixListener::bind(SOCKET_PATH)
-            .context("Failed to bind enrollment socket")?;
+        let listener =
+            AsyncUnixListener::bind(SOCKET_PATH).context("Failed to bind enrollment socket")?;
 
         info!("Enrollment server listening on {}", SOCKET_PATH);
 
@@ -53,7 +53,14 @@ impl EnrollmentServer {
                     let alt_enrollment = self.alt_enrollment.clone();
 
                     tokio::spawn(async move {
-                        if let Err(e) = Self::handle_client(stream, process_tracker, policy_manager, alt_enrollment).await {
+                        if let Err(e) = Self::handle_client(
+                            stream,
+                            process_tracker,
+                            policy_manager,
+                            alt_enrollment,
+                        )
+                        .await
+                        {
                             error!("Error handling enrollment client: {}", e);
                         }
                     });
@@ -71,7 +78,8 @@ impl EnrollmentServer {
         policy_manager: Arc<RwLock<PolicyManager>>,
         alt_enrollment: Arc<AlternativeEnrollment>,
     ) -> Result<()> {
-        let peer_creds = stream.peer_cred()
+        let peer_creds = stream
+            .peer_cred()
             .context("Failed to get peer credentials")?;
 
         let pid = peer_creds.pid().unwrap_or(0);
@@ -81,12 +89,15 @@ impl EnrollmentServer {
         let mut line = String::new();
         reader.read_line(&mut line).await?;
 
-        let request: EnrollmentRequest = serde_json::from_str(&line)
-            .context("Failed to parse enrollment request")?;
+        let request: EnrollmentRequest =
+            serde_json::from_str(&line).context("Failed to parse enrollment request")?;
 
         let response = match request {
             EnrollmentRequest::Enroll { pod_id, role_id } => {
-                debug!("Enrollment request: PID {} -> Pod {} Role {}", pid, pod_id.0, role_id.0);
+                debug!(
+                    "Enrollment request: PID {} -> Pod {} Role {}",
+                    pid, pod_id.0, role_id.0
+                );
 
                 let pm = policy_manager.read().await;
                 match pm.get_role(role_id) {
@@ -100,18 +111,24 @@ impl EnrollmentServer {
                             EnrollmentResponse::Error(format!("Failed to set role policy: {}", e))
                         } else {
                             // Apply network rules from the role
-                            if let Err(e) = process_tracker.apply_network_rules(role_id, &role.network_rules) {
+                            if let Err(e) =
+                                process_tracker.apply_network_rules(role_id, &role.network_rules)
+                            {
                                 error!("Failed to apply network rules: {}", e);
                             }
 
                             // Apply path rules from the role
-                            if let Err(e) = process_tracker.apply_path_rules(role_id, &role.file_paths) {
+                            if let Err(e) =
+                                process_tracker.apply_path_rules(role_id, &role.file_paths)
+                            {
                                 error!("Failed to apply path rules: {}", e);
                             }
 
                             match process_tracker.enroll_process(pid as u32, pod_id, role_id) {
                                 Ok(()) => EnrollmentResponse::Success,
-                                Err(e) => EnrollmentResponse::Error(format!("Enrollment failed: {}", e)),
+                                Err(e) => {
+                                    EnrollmentResponse::Error(format!("Enrollment failed: {}", e))
+                                }
                             }
                         }
                     }
@@ -126,28 +143,54 @@ impl EnrollmentServer {
                     Ok(None) => {
                         EnrollmentResponse::Error("Process not found or not enrolled".to_string())
                     }
-                    Err(e) => {
-                        EnrollmentResponse::Error(format!("Query failed: {}", e))
-                    }
+                    Err(e) => EnrollmentResponse::Error(format!("Query failed: {}", e)),
                 }
             }
-            EnrollmentRequest::EnrollExecutable { executable_path, pod_id, role_id } => {
-                debug!("Enroll executable request: {} -> Pod {} Role {}", executable_path, pod_id.0, role_id.0);
-                match alt_enrollment.enroll_by_executable_path(&executable_path, pod_id, role_id).await {
+            EnrollmentRequest::EnrollExecutable {
+                executable_path,
+                pod_id,
+                role_id,
+            } => {
+                debug!(
+                    "Enroll executable request: {} -> Pod {} Role {}",
+                    executable_path, pod_id.0, role_id.0
+                );
+                match alt_enrollment
+                    .enroll_by_executable_path(&executable_path, pod_id, role_id)
+                    .await
+                {
                     Ok(()) => EnrollmentResponse::Success,
-                    Err(e) => EnrollmentResponse::Error(format!("Failed to enroll executable: {}", e)),
+                    Err(e) => {
+                        EnrollmentResponse::Error(format!("Failed to enroll executable: {}", e))
+                    }
                 }
             }
             EnrollmentRequest::RemoveExecutable { executable_path } => {
                 debug!("Remove executable enrollment: {}", executable_path);
-                match alt_enrollment.remove_executable_enrollment(&executable_path).await {
+                match alt_enrollment
+                    .remove_executable_enrollment(&executable_path)
+                    .await
+                {
                     Ok(()) => EnrollmentResponse::Success,
-                    Err(e) => EnrollmentResponse::Error(format!("Failed to remove executable enrollment: {}", e)),
+                    Err(e) => EnrollmentResponse::Error(format!(
+                        "Failed to remove executable enrollment: {}",
+                        e
+                    )),
                 }
             }
-            EnrollmentRequest::EnrollCgroup { cgroup_path, pod_id, role_id } => {
-                debug!("Enroll cgroup request: {} -> Pod {} Role {}", cgroup_path, pod_id.0, role_id.0);
-                match alt_enrollment.enroll_by_cgroup_path(&cgroup_path, pod_id, role_id).await {
+            EnrollmentRequest::EnrollCgroup {
+                cgroup_path,
+                pod_id,
+                role_id,
+            } => {
+                debug!(
+                    "Enroll cgroup request: {} -> Pod {} Role {}",
+                    cgroup_path, pod_id.0, role_id.0
+                );
+                match alt_enrollment
+                    .enroll_by_cgroup_path(&cgroup_path, pod_id, role_id)
+                    .await
+                {
                     Ok(()) => EnrollmentResponse::Success,
                     Err(e) => EnrollmentResponse::Error(format!("Failed to enroll cgroup: {}", e)),
                 }
@@ -156,29 +199,58 @@ impl EnrollmentServer {
                 debug!("Remove cgroup enrollment: {}", cgroup_path);
                 match alt_enrollment.remove_cgroup_enrollment(&cgroup_path).await {
                     Ok(()) => EnrollmentResponse::Success,
-                    Err(e) => EnrollmentResponse::Error(format!("Failed to remove cgroup enrollment: {}", e)),
+                    Err(e) => EnrollmentResponse::Error(format!(
+                        "Failed to remove cgroup enrollment: {}",
+                        e
+                    )),
                 }
             }
-            EnrollmentRequest::SetXattr { executable_path, pod_id, role_id } => {
-                debug!("Set xattr enrollment: {} -> Pod {} Role {}", executable_path, pod_id.0, role_id.0);
-                match alt_enrollment.set_xattr_enrollment(&executable_path, pod_id, role_id).await {
+            EnrollmentRequest::SetXattr {
+                executable_path,
+                pod_id,
+                role_id,
+            } => {
+                debug!(
+                    "Set xattr enrollment: {} -> Pod {} Role {}",
+                    executable_path, pod_id.0, role_id.0
+                );
+                match alt_enrollment
+                    .set_xattr_enrollment(&executable_path, pod_id, role_id)
+                    .await
+                {
                     Ok(()) => EnrollmentResponse::Success,
-                    Err(e) => EnrollmentResponse::Error(format!("Failed to set xattr enrollment: {}", e)),
+                    Err(e) => {
+                        EnrollmentResponse::Error(format!("Failed to set xattr enrollment: {}", e))
+                    }
                 }
             }
             EnrollmentRequest::CheckXattr { executable_path } => {
                 debug!("Check xattr enrollment: {}", executable_path);
-                match alt_enrollment.check_xattr_enrollment(&executable_path).await {
-                    Ok(Some((pod_id, role_id))) => EnrollmentResponse::XattrInfo { pod_id, role_id },
+                match alt_enrollment
+                    .check_xattr_enrollment(&executable_path)
+                    .await
+                {
+                    Ok(Some((pod_id, role_id))) => {
+                        EnrollmentResponse::XattrInfo { pod_id, role_id }
+                    }
                     Ok(None) => EnrollmentResponse::Error("No xattr enrollment found".to_string()),
-                    Err(e) => EnrollmentResponse::Error(format!("Failed to check xattr enrollment: {}", e)),
+                    Err(e) => EnrollmentResponse::Error(format!(
+                        "Failed to check xattr enrollment: {}",
+                        e
+                    )),
                 }
             }
             EnrollmentRequest::RemoveXattr { executable_path } => {
                 debug!("Remove xattr enrollment: {}", executable_path);
-                match alt_enrollment.remove_xattr_enrollment(&executable_path).await {
+                match alt_enrollment
+                    .remove_xattr_enrollment(&executable_path)
+                    .await
+                {
                     Ok(()) => EnrollmentResponse::Success,
-                    Err(e) => EnrollmentResponse::Error(format!("Failed to remove xattr enrollment: {}", e)),
+                    Err(e) => EnrollmentResponse::Error(format!(
+                        "Failed to remove xattr enrollment: {}",
+                        e
+                    )),
                 }
             }
         };

--- a/bpfjailer-daemon/src/enrollment_alternatives.rs
+++ b/bpfjailer-daemon/src/enrollment_alternatives.rs
@@ -1,12 +1,12 @@
+use crate::bpf_loader::BpfJailerBpf;
+use crate::policy::PolicyManager;
+use crate::process_tracker::ProcessTracker;
 use anyhow::{Context, Result};
 use bpfjailer_common::{PodId, RoleId};
 use log::{debug, info, warn};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use crate::process_tracker::ProcessTracker;
-use crate::policy::PolicyManager;
-use crate::bpf_loader::BpfJailerBpf;
 
 /// Alternative enrollment methods beyond Unix socket
 pub struct AlternativeEnrollment {
@@ -36,11 +36,16 @@ impl AlternativeEnrollment {
         pod_id: PodId,
         role_id: RoleId,
     ) -> Result<()> {
-        info!("Setting up executable enrollment: {} -> Pod {} Role {}",
-              executable_path, pod_id.0, role_id.0);
+        info!(
+            "Setting up executable enrollment: {} -> Pod {} Role {}",
+            executable_path, pod_id.0, role_id.0
+        );
 
         if !Path::new(executable_path).exists() {
-            return Err(anyhow::anyhow!("Executable path does not exist: {}", executable_path));
+            return Err(anyhow::anyhow!(
+                "Executable path does not exist: {}",
+                executable_path
+            ));
         }
 
         // Get the inode of the executable
@@ -55,8 +60,10 @@ impl AlternativeEnrollment {
 
             // Set up role flags and rules
             self.process_tracker.set_role_policy(role_id, &role.flags)?;
-            self.process_tracker.apply_network_rules(role_id, &role.network_rules)?;
-            self.process_tracker.apply_path_rules(role_id, &role.file_paths)?;
+            self.process_tracker
+                .apply_network_rules(role_id, &role.network_rules)?;
+            self.process_tracker
+                .apply_path_rules(role_id, &role.file_paths)?;
         } else {
             return Err(anyhow::anyhow!("Unknown role ID: {}", role_id.0));
         }
@@ -64,8 +71,10 @@ impl AlternativeEnrollment {
         // Add the executable enrollment rule
         self.bpf.add_exec_enrollment(inode, pod_id.0, role_id.0)?;
 
-        info!("Executable enrollment active: {} (inode={}) -> Pod {} Role {}",
-              executable_path, inode, pod_id.0, role_id.0);
+        info!(
+            "Executable enrollment active: {} (inode={}) -> Pod {} Role {}",
+            executable_path, inode, pod_id.0, role_id.0
+        );
         Ok(())
     }
 
@@ -85,16 +94,21 @@ impl AlternativeEnrollment {
         pod_id: PodId,
         role_id: RoleId,
     ) -> Result<()> {
-        info!("Setting up cgroup enrollment: {} -> Pod {} Role {}",
-              cgroup_path, pod_id.0, role_id.0);
+        info!(
+            "Setting up cgroup enrollment: {} -> Pod {} Role {}",
+            cgroup_path, pod_id.0, role_id.0
+        );
 
         if !Path::new(cgroup_path).exists() {
-            return Err(anyhow::anyhow!("Cgroup path does not exist: {}", cgroup_path));
+            return Err(anyhow::anyhow!(
+                "Cgroup path does not exist: {}",
+                cgroup_path
+            ));
         }
 
         // Get the cgroup ID
-        let cgroup_id = BpfJailerBpf::get_cgroup_id(cgroup_path)
-            .context("Failed to get cgroup ID")?;
+        let cgroup_id =
+            BpfJailerBpf::get_cgroup_id(cgroup_path).context("Failed to get cgroup ID")?;
 
         // Ensure role policy is loaded
         let pm = self.policy_manager.read().await;
@@ -104,24 +118,29 @@ impl AlternativeEnrollment {
 
             // Set up role flags and rules
             self.process_tracker.set_role_policy(role_id, &role.flags)?;
-            self.process_tracker.apply_network_rules(role_id, &role.network_rules)?;
-            self.process_tracker.apply_path_rules(role_id, &role.file_paths)?;
+            self.process_tracker
+                .apply_network_rules(role_id, &role.network_rules)?;
+            self.process_tracker
+                .apply_path_rules(role_id, &role.file_paths)?;
         } else {
             return Err(anyhow::anyhow!("Unknown role ID: {}", role_id.0));
         }
 
         // Add the cgroup enrollment rule
-        self.bpf.add_cgroup_enrollment(cgroup_id, pod_id.0, role_id.0)?;
+        self.bpf
+            .add_cgroup_enrollment(cgroup_id, pod_id.0, role_id.0)?;
 
-        info!("Cgroup enrollment active: {} (id={}) -> Pod {} Role {}",
-              cgroup_path, cgroup_id, pod_id.0, role_id.0);
+        info!(
+            "Cgroup enrollment active: {} (id={}) -> Pod {} Role {}",
+            cgroup_path, cgroup_id, pod_id.0, role_id.0
+        );
         Ok(())
     }
 
     /// Remove cgroup-based enrollment
     pub async fn remove_cgroup_enrollment(&self, cgroup_path: &str) -> Result<()> {
-        let cgroup_id = BpfJailerBpf::get_cgroup_id(cgroup_path)
-            .context("Failed to get cgroup ID")?;
+        let cgroup_id =
+            BpfJailerBpf::get_cgroup_id(cgroup_path).context("Failed to get cgroup ID")?;
         self.bpf.remove_cgroup_enrollment(cgroup_id)?;
         info!("Removed cgroup enrollment for: {}", cgroup_path);
         Ok(())
@@ -135,11 +154,16 @@ impl AlternativeEnrollment {
         pod_id: PodId,
         role_id: RoleId,
     ) -> Result<()> {
-        info!("Setting xattr enrollment: {} -> Pod {} Role {}",
-              executable_path, pod_id.0, role_id.0);
+        info!(
+            "Setting xattr enrollment: {} -> Pod {} Role {}",
+            executable_path, pod_id.0, role_id.0
+        );
 
         if !Path::new(executable_path).exists() {
-            return Err(anyhow::anyhow!("Executable path does not exist: {}", executable_path));
+            return Err(anyhow::anyhow!(
+                "Executable path does not exist: {}",
+                executable_path
+            ));
         }
 
         // Set pod_id xattr
@@ -159,7 +183,10 @@ impl AlternativeEnrollment {
     }
 
     /// Check xattr on executable for enrollment info
-    pub async fn check_xattr_enrollment(&self, executable_path: &str) -> Result<Option<(PodId, RoleId)>> {
+    pub async fn check_xattr_enrollment(
+        &self,
+        executable_path: &str,
+    ) -> Result<Option<(PodId, RoleId)>> {
         let pod_xattr = "user.bpfjailer.pod_id";
         let role_xattr = "user.bpfjailer.role_id";
 
@@ -179,15 +206,22 @@ impl AlternativeEnrollment {
         }
 
         let pod_id = u64::from_le_bytes([
-            pod_value[0], pod_value[1], pod_value[2], pod_value[3],
-            pod_value[4], pod_value[5], pod_value[6], pod_value[7],
+            pod_value[0],
+            pod_value[1],
+            pod_value[2],
+            pod_value[3],
+            pod_value[4],
+            pod_value[5],
+            pod_value[6],
+            pod_value[7],
         ]);
-        let role_id = u32::from_le_bytes([
-            role_value[0], role_value[1], role_value[2], role_value[3],
-        ]);
+        let role_id =
+            u32::from_le_bytes([role_value[0], role_value[1], role_value[2], role_value[3]]);
 
-        debug!("Found xattr enrollment: {} -> Pod {} Role {}",
-               executable_path, pod_id, role_id);
+        debug!(
+            "Found xattr enrollment: {} -> Pod {} Role {}",
+            executable_path, pod_id, role_id
+        );
         Ok(Some((PodId(pod_id), RoleId(role_id))))
     }
 
@@ -209,15 +243,27 @@ impl AlternativeEnrollment {
 
         // Load executable enrollments from policy
         for (exec_path, pod_id, role_id) in pm.get_exec_enrollments() {
-            if let Err(e) = self.enroll_by_executable_path(&exec_path, pod_id, role_id).await {
-                warn!("Failed to set up executable enrollment for {}: {}", exec_path, e);
+            if let Err(e) = self
+                .enroll_by_executable_path(&exec_path, pod_id, role_id)
+                .await
+            {
+                warn!(
+                    "Failed to set up executable enrollment for {}: {}",
+                    exec_path, e
+                );
             }
         }
 
         // Load cgroup enrollments from policy
         for (cgroup_path, pod_id, role_id) in pm.get_cgroup_enrollments() {
-            if let Err(e) = self.enroll_by_cgroup_path(&cgroup_path, pod_id, role_id).await {
-                warn!("Failed to set up cgroup enrollment for {}: {}", cgroup_path, e);
+            if let Err(e) = self
+                .enroll_by_cgroup_path(&cgroup_path, pod_id, role_id)
+                .await
+            {
+                warn!(
+                    "Failed to set up cgroup enrollment for {}: {}",
+                    cgroup_path, e
+                );
             }
         }
 

--- a/bpfjailer-daemon/src/main.rs
+++ b/bpfjailer-daemon/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
     // Apply IP rules, domain rules, and proxy config from policy
     {
         let pm = policy_manager.read().await;
-        for (_name, role) in pm.config().roles.iter() {
+        for role in pm.config().roles.values() {
             let role_id = role.id;
 
             // Apply IP rules

--- a/bpfjailer-daemon/src/main.rs
+++ b/bpfjailer-daemon/src/main.rs
@@ -1,9 +1,9 @@
 mod bpf_loader;
-mod process_tracker;
-mod policy;
 mod enrollment;
 mod enrollment_alternatives;
 mod path_matcher;
+mod policy;
+mod process_tracker;
 mod signed_binary;
 
 use anyhow::Result;
@@ -35,17 +35,15 @@ async fn main() -> Result<()> {
     let mut policy_manager = policy::PolicyManager::new()?;
 
     // Load policy from file if available
-    let policy_path = env::var("BPFJAILER_POLICY")
-        .ok()
-        .or_else(|| {
-            if Path::new(DEFAULT_POLICY_PATH).exists() {
-                Some(DEFAULT_POLICY_PATH.to_string())
-            } else if Path::new(LOCAL_POLICY_PATH).exists() {
-                Some(LOCAL_POLICY_PATH.to_string())
-            } else {
-                None
-            }
-        });
+    let policy_path = env::var("BPFJAILER_POLICY").ok().or_else(|| {
+        if Path::new(DEFAULT_POLICY_PATH).exists() {
+            Some(DEFAULT_POLICY_PATH.to_string())
+        } else if Path::new(LOCAL_POLICY_PATH).exists() {
+            Some(LOCAL_POLICY_PATH.to_string())
+        } else {
+            None
+        }
+    });
 
     if let Some(path) = policy_path {
         match policy_manager.load_from_file(&path).await {
@@ -64,7 +62,10 @@ async fn main() -> Result<()> {
     // Compile path patterns from loaded policy and invalidate cache
     {
         let pm = policy_manager.read().await;
-        let all_patterns: Vec<String> = pm.config().roles.values()
+        let all_patterns: Vec<String> = pm
+            .config()
+            .roles
+            .values()
             .flat_map(|role| role.file_paths.iter().map(|p| p.pattern.clone()))
             .collect();
         drop(pm);

--- a/bpfjailer-daemon/src/path_matcher.rs
+++ b/bpfjailer-daemon/src/path_matcher.rs
@@ -1,7 +1,7 @@
+use crate::bpf_loader::BpfJailerBpf;
 use anyhow::{Context, Result};
 use log::info;
 use std::sync::Arc;
-use crate::bpf_loader::BpfJailerBpf;
 
 pub struct PathMatcher {
     bpf: Arc<BpfJailerBpf>,
@@ -23,11 +23,17 @@ impl PathMatcher {
                 return Err(anyhow::anyhow!("Empty path pattern not allowed"));
             }
             if !pattern.starts_with('/') {
-                return Err(anyhow::anyhow!("Path pattern must be absolute (start with /): {}", pattern));
+                return Err(anyhow::anyhow!(
+                    "Path pattern must be absolute (start with /): {}",
+                    pattern
+                ));
             }
             // Check for invalid wildcard usage
             if pattern.contains("***") {
-                return Err(anyhow::anyhow!("Invalid wildcard pattern (triple asterisk): {}", pattern));
+                return Err(anyhow::anyhow!(
+                    "Invalid wildcard pattern (triple asterisk): {}",
+                    pattern
+                ));
             }
         }
 
@@ -38,7 +44,8 @@ impl PathMatcher {
     /// Invalidate the inode cache by incrementing cache generation counter
     pub fn invalidate_cache(&self) -> Result<()> {
         info!("Invalidating path matching cache");
-        self.bpf.invalidate_cache()
+        self.bpf
+            .invalidate_cache()
             .context("Failed to invalidate cache")
     }
 }

--- a/bpfjailer-daemon/src/policy.rs
+++ b/bpfjailer-daemon/src/policy.rs
@@ -84,7 +84,7 @@ impl PolicyManager {
         self.config = serde_json::from_str(&content)?;
 
         self.role_map.clear();
-        for (_name, role) in &self.config.roles {
+        for role in self.config.roles.values() {
             self.role_map.insert(role.id, Arc::new(role.clone()));
         }
 

--- a/bpfjailer-daemon/src/policy.rs
+++ b/bpfjailer-daemon/src/policy.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use bpfjailer_common::{PolicyConfig, PolicyFlags, PodId, Role, RoleId};
+use bpfjailer_common::{PodId, PolicyConfig, PolicyFlags, Role, RoleId};
 use log::info;
 use std::collections::HashMap;
 use std::path::Path;
@@ -65,17 +65,18 @@ impl PolicyManager {
             proxy: None,
         };
 
-        config.roles.insert("restricted".to_string(), restricted_role.clone());
-        config.roles.insert("permissive".to_string(), permissive_role.clone());
+        config
+            .roles
+            .insert("restricted".to_string(), restricted_role.clone());
+        config
+            .roles
+            .insert("permissive".to_string(), permissive_role.clone());
         role_map.insert(RoleId(1), Arc::new(restricted_role));
         role_map.insert(RoleId(2), Arc::new(permissive_role));
 
         info!("Initialized with default roles: restricted (1), permissive (2)");
 
-        Ok(Self {
-            config,
-            role_map,
-        })
+        Ok(Self { config, role_map })
     }
 
     pub async fn load_from_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
@@ -98,9 +99,9 @@ impl PolicyManager {
 
     #[allow(dead_code)]
     pub fn get_role_by_name(&self, name: &str) -> Option<&Arc<Role>> {
-        self.config.get_role(name).map(|r| {
-            self.role_map.get(&r.id).unwrap()
-        })
+        self.config
+            .get_role(name)
+            .map(|r| self.role_map.get(&r.id).unwrap())
     }
 
     pub fn config(&self) -> &PolicyConfig {
@@ -109,9 +110,12 @@ impl PolicyManager {
 
     /// Get executable enrollments from policy
     pub fn get_exec_enrollments(&self) -> Vec<(String, PodId, RoleId)> {
-        self.config.exec_enrollments.iter()
+        self.config
+            .exec_enrollments
+            .iter()
             .filter_map(|e| {
-                self.config.get_role(&e.role)
+                self.config
+                    .get_role(&e.role)
                     .map(|r| (e.executable_path.clone(), PodId(e.pod_id), r.id))
             })
             .collect()
@@ -119,9 +123,12 @@ impl PolicyManager {
 
     /// Get cgroup enrollments from policy
     pub fn get_cgroup_enrollments(&self) -> Vec<(String, PodId, RoleId)> {
-        self.config.cgroup_enrollments.iter()
+        self.config
+            .cgroup_enrollments
+            .iter()
             .filter_map(|e| {
-                self.config.get_role(&e.role)
+                self.config
+                    .get_role(&e.role)
                     .map(|r| (e.cgroup_path.clone(), PodId(e.pod_id), r.id))
             })
             .collect()

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -1,8 +1,10 @@
+use crate::bpf_loader::BpfJailerBpf;
 use anyhow::{Context, Result};
-use bpfjailer_common::{DomainRule, IpRule, NetworkRule, PathPattern, PodId, PolicyFlags, ProxyConfig, RoleId};
+use bpfjailer_common::{
+    DomainRule, IpRule, NetworkRule, PathPattern, PodId, PolicyFlags, ProxyConfig, RoleId,
+};
 use log::{debug, info, warn};
 use std::sync::Arc;
-use crate::bpf_loader::BpfJailerBpf;
 
 // Protocol constants
 pub const PROTO_TCP: u8 = 6;
@@ -40,18 +42,26 @@ impl ProcessTracker {
     }
 
     pub fn enroll_process(&self, pid: u32, pod_id: PodId, role_id: RoleId) -> Result<()> {
-        info!("Enrolling process {} into pod {} with role {}", pid, pod_id.0, role_id.0);
+        info!(
+            "Enrolling process {} into pod {} with role {}",
+            pid, pod_id.0, role_id.0
+        );
 
         // Update pod_to_role mapping
-        self.bpf.update_pod_role(pod_id.0, role_id.0)
+        self.bpf
+            .update_pod_role(pod_id.0, role_id.0)
             .context("Failed to insert pod_to_role mapping")?;
 
         // Add to pending_enrollments map - BPF will migrate to task_storage
         // on the next syscall (file_open, exec, etc.)
-        self.bpf.enroll_pending_process(pid, pod_id.0, role_id.0)
+        self.bpf
+            .enroll_pending_process(pid, pod_id.0, role_id.0)
             .context("Failed to add pending enrollment")?;
 
-        info!("Process {} enrolled successfully (pending migration to task_storage)", pid);
+        info!(
+            "Process {} enrolled successfully (pending migration to task_storage)",
+            pid
+        );
         Ok(())
     }
 
@@ -64,7 +74,8 @@ impl ProcessTracker {
 
     #[allow(dead_code)]
     pub fn update_role_flags(&self, role_id: RoleId, flags: u8) -> Result<()> {
-        self.bpf.update_role_flags(role_id.0, flags)
+        self.bpf
+            .update_role_flags(role_id.0, flags)
             .context("Failed to update role flags")?;
         Ok(())
     }
@@ -72,15 +83,24 @@ impl ProcessTracker {
     pub fn set_role_policy(&self, role_id: RoleId, flags: &PolicyFlags) -> Result<()> {
         let flags_u8 = policy_flags_to_u8(flags);
         info!("Setting role {} flags to 0x{:02x}", role_id.0, flags_u8);
-        self.bpf.update_role_flags(role_id.0, flags_u8)
+        self.bpf
+            .update_role_flags(role_id.0, flags_u8)
             .context("Failed to set role policy flags")?;
         Ok(())
     }
 
     /// Add a network rule for a role
     /// port: 0 = all ports
-    pub fn add_network_rule(&self, role_id: RoleId, port: u16, protocol: u8, direction: u8, allowed: bool) -> Result<()> {
-        self.bpf.add_network_rule(role_id.0, port, protocol, direction, allowed)
+    pub fn add_network_rule(
+        &self,
+        role_id: RoleId,
+        port: u16,
+        protocol: u8,
+        direction: u8,
+        allowed: bool,
+    ) -> Result<()> {
+        self.bpf
+            .add_network_rule(role_id.0, port, protocol, direction, allowed)
             .context("Failed to add network rule")
     }
 
@@ -97,7 +117,8 @@ impl ProcessTracker {
             };
 
             // Handle port range or single port
-            let ports: Vec<u16> = if let (Some(start), Some(end)) = (rule.port_start, rule.port_end) {
+            let ports: Vec<u16> = if let (Some(start), Some(end)) = (rule.port_start, rule.port_end)
+            {
                 // Port range specified
                 if start > end {
                     warn!("Invalid port range {}-{}, skipping", start, end);
@@ -105,8 +126,10 @@ impl ProcessTracker {
                 }
                 let range_size = (end - start + 1) as usize;
                 if range_size > 1000 {
-                    warn!("Port range {}-{} has {} ports (large ranges use many map entries)",
-                          start, end, range_size);
+                    warn!(
+                        "Port range {}-{} has {} ports (large ranges use many map entries)",
+                        start, end, range_size
+                    );
                 }
                 (start..=end).collect()
             } else if let Some(port) = rule.port {
@@ -130,8 +153,12 @@ impl ProcessTracker {
             } else {
                 info!(
                     "Applied network rule: role={} ports={}-{} ({} ports) proto={} allow={}",
-                    role_id.0, rule.port_start.unwrap(), rule.port_end.unwrap(),
-                    ports.len(), rule.protocol, rule.allow
+                    role_id.0,
+                    rule.port_start.unwrap(),
+                    rule.port_end.unwrap(),
+                    ports.len(),
+                    rule.protocol,
+                    rule.allow
                 );
             }
         }
@@ -141,13 +168,15 @@ impl ProcessTracker {
     /// Add a path rule for a role (legacy hash-based)
     #[allow(dead_code)]
     pub fn add_path_rule(&self, role_id: RoleId, path: &str, allowed: bool) -> Result<()> {
-        self.bpf.add_path_rule(role_id.0, path, allowed)
+        self.bpf
+            .add_path_rule(role_id.0, path, allowed)
             .context("Failed to add path rule")
     }
 
     /// Add a path state (dentry-walking state machine)
     pub fn add_path_state(&self, role_id: RoleId, pattern: &str, allowed: bool) -> Result<()> {
-        self.bpf.add_path_state(role_id.0, pattern, allowed)
+        self.bpf
+            .add_path_state(role_id.0, pattern, allowed)
             .context("Failed to add path state")
     }
 
@@ -180,8 +209,15 @@ impl ProcessTracker {
     // =========================================================================
 
     /// Add an IP/CIDR rule for egress filtering
-    pub fn add_ip_rule(&self, role_id: RoleId, cidr: &str, direction: u8, allowed: bool) -> Result<()> {
-        self.bpf.add_ip_rule(role_id.0, cidr, direction, allowed)
+    pub fn add_ip_rule(
+        &self,
+        role_id: RoleId,
+        cidr: &str,
+        direction: u8,
+        allowed: bool,
+    ) -> Result<()> {
+        self.bpf
+            .add_ip_rule(role_id.0, cidr, direction, allowed)
             .context("Failed to add IP rule")
     }
 
@@ -191,7 +227,7 @@ impl ProcessTracker {
             let direction = match rule.direction.to_lowercase().as_str() {
                 "bind" => DIR_BIND,
                 "connect" => DIR_CONNECT,
-                _ => DIR_CONNECT,  // Default to connect for egress control
+                _ => DIR_CONNECT, // Default to connect for egress control
             };
 
             self.add_ip_rule(role_id, &rule.cidr, direction, rule.allow)?;
@@ -206,13 +242,15 @@ impl ProcessTracker {
 
     /// Configure proxy requirement for a role
     pub fn set_proxy_config(&self, role_id: RoleId, config: &ProxyConfig) -> Result<()> {
-        self.bpf.set_proxy_config(role_id.0, &config.address, config.required)
+        self.bpf
+            .set_proxy_config(role_id.0, &config.address, config.required)
             .context("Failed to set proxy config")
     }
 
     /// Add a domain rule for egress filtering
     pub fn add_domain_rule(&self, role_id: RoleId, domain: &str, allowed: bool) -> Result<()> {
-        self.bpf.add_domain_rule(role_id.0, domain, allowed)
+        self.bpf
+            .add_domain_rule(role_id.0, domain, allowed)
             .context("Failed to add domain rule")
     }
 

--- a/bpfjailer-daemon/src/signed_binary.rs
+++ b/bpfjailer-daemon/src/signed_binary.rs
@@ -7,6 +7,9 @@ pub struct SignedBinaryManager {
     _bpf: Arc<BpfJailerBpf>,
 }
 
+// Signature validation is not wired up yet (README lists it as a stub), so
+// these are intentionally unreferenced until the enforcement path lands.
+#[allow(dead_code)]
 impl SignedBinaryManager {
     pub fn new(bpf: Arc<BpfJailerBpf>) -> Result<Self> {
         info!("Initializing signed binary manager");

--- a/bpfjailer-daemon/src/signed_binary.rs
+++ b/bpfjailer-daemon/src/signed_binary.rs
@@ -1,7 +1,7 @@
+use crate::bpf_loader::BpfJailerBpf;
 use anyhow::Result;
 use log::info;
 use std::sync::Arc;
-use crate::bpf_loader::BpfJailerBpf;
 
 pub struct SignedBinaryManager {
     _bpf: Arc<BpfJailerBpf>,

--- a/test_task_storage/Cargo.toml
+++ b/test_task_storage/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 
 [dependencies]
 libbpf-rs = "0.21"
-libbpf-sys = "1.4"
 anyhow = "1.0"
 log = "0.4"
 env_logger = "0.11"


### PR DESCRIPTION
## Problem

`main` does not compile.

`libbpf-rs` 0.26 changed the `Object` / `Map` API surface, so the
`0.21.2 -> 0.26.1` bump in d8a93fc left both binaries failing to build:

```
error: could not compile `bpfjailer-bootstrap` due to 11 previous errors
error: could not compile `bpfjailer-daemon`    due to 36 previous errors
```

47 of the errors are `E0599` (method not found), e.g. `object.map(name)` no
longer resolving on the new `Object` type.

There were no CI workflows in the repository, and dependabot runs daily, so the
bump merged without ever being compiled.

## Changes

Four commits, each reviewable on its own.

**1. `c3fc548` — restore a compiling tree.** Pin `libbpf-rs` back to `0.21` in
the workspace root, `bpfjailer-bootstrap` and `bpfjailer-daemon`. Deliberately a
revert rather than a migration: adapting the call sites to the 0.26 API is real
work and belongs in its own PR where it can be reviewed on its merits.

Also adds `.github/workflows/build.yml`, which builds the BPF objects first
(they are produced by `bpfjailer-bpf/build.rs` via clang and loaded at runtime),
then the workspace, then asserts the three shipped artifacts exist. And tightens
dependabot: group minor/patch bumps, stop it raising `libbpf-rs` major bumps,
which need a manual migration.

**2. `f75c16f` — fix the existing clippy findings.**

- `PolicyConfig`: add `Default` delegating to `new()`
- `PolicyFlags`: derive `Default` (every field is `false`)
- `policy.rs`: iterate `roles.values()` instead of discarding the key
- `signed_binary.rs`: `allow(dead_code)` on the signature-validation stub the
  README lists as planned, so the scaffolding stays without failing the lint
- `bpf_loader.rs`: document the `Arc<Mutex<Object>>` allow — `libbpf_rs::Object`
  is neither `Send` nor `Sync` and the loader is single-threaded today

The last two are annotations rather than rewrites on purpose. Restructuring the
BPF loader's sharing model is a design decision, not something to slip into a CI
change.

**3. `b97c9a5` — `cargo fmt --all`.** Mechanical, 13 files. Split out so it can
be reviewed or dropped independently of the functional changes.

**4. `8dbbe1b` — add `.github/workflows/wellness-check.yml`.** fmt,
unused-dependency scan, clippy with `--deny warnings`, rustdoc with
`-D warnings`, unit tests, and miri.

## Why the gates are blocking

Commits 2 and 3 exist so they can be. `cargo fmt --check` had 124 diff hunks and
clippy had 5 findings on `main`; adding these jobs without fixing that would
have meant either a permanently red CI or non-blocking jobs that everyone
learns to ignore.

miri is restricted to `bpfjailer-common` — the bootstrap and daemon crates wrap
libbpf via FFI and load BPF objects, which miri cannot model. Sanitizers are
omitted for the same reason: they would report the C library, not this code.

## Verification

On this branch, locally:

```
cargo fmt --all --check                                       PASS
cargo clippy --locked --workspace --all-targets -- -D warnings PASS
cargo doc --locked --workspace --no-deps  (RUSTDOCFLAGS=-D warnings)  PASS
cargo test --locked --workspace --lib                          PASS
cargo build --release                                          PASS
```

`bpfjailer-bootstrap` from this branch also loads and pins the LSM programs on a
6.18 kernel with `CONFIG_BPF_LSM=y` and `bpf` in the active LSM list.

Note `cargo test --lib` currently runs zero tests — the workspace has no unit
tests. The job is wired up so that changes.

## Follow-up

Migrating to `libbpf-rs` 0.26 is still worth doing; this PR only unblocks the
build. With CI in place that migration can be verified before it lands.
