### PR TITLE
Replace djb2 path hashing with FNV-1a 64 to stop false-positive policy matches

### DIFF
--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -279,7 +279,7 @@ fn add_path_state(map: &libbpf_rs::Map, role_id: u32, pattern: &str, allowed: bo
         return Ok(());
     }
 
-    let mut state: u32 = 0;
+    let mut state: u64 = 0;
 
     for (i, component) in components.iter().enumerate() {
         let is_last = i == components.len() - 1;
@@ -287,30 +287,34 @@ fn add_path_state(map: &libbpf_rs::Map, role_id: u32, pattern: &str, allowed: bo
         let component_hash = if is_wildcard {
             0
         } else {
-            djb2_hash_u32(component)
+            bpfjailer_common::hash::fnv1a_hash_u64(component)
         };
 
-        let mut key = [0u8; 12];
+        let mut key = [0u8; 24];
         key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[4..8].copy_from_slice(&state.to_ne_bytes());
-        key[8..12].copy_from_slice(&component_hash.to_ne_bytes());
+        key[8..16].copy_from_slice(&state.to_ne_bytes());
+        key[16..24].copy_from_slice(&component_hash.to_ne_bytes());
 
         let next_state = if is_last {
             if allowed {
-                0xFFFFFFFE
+                0xFFFF_FFFF_FFFF_FFFE_u64
             } else {
-                0xFFFFFFFF
+                0xFFFF_FFFF_FFFF_FFFF_u64
             }
         } else {
-            djb2_hash_u32(&format!("{}:{}", role_id, components[..=i].join("/")))
+            bpfjailer_common::hash::fnv1a_hash_u64(&format!(
+                "{}:{}",
+                role_id,
+                components[..=i].join("/")
+            ))
         };
 
-        let mut value = [0u8; 8];
-        value[0..4].copy_from_slice(&next_state.to_ne_bytes());
-        value[4] = if is_last { 1 } else { 0 };
-        value[5] = if allowed { 1 } else { 0 };
-        value[6] = if is_wildcard { 1 } else { 0 };
-        value[7] = 0;
+        let mut value = [0u8; 16];
+        value[0..8].copy_from_slice(&next_state.to_ne_bytes());
+        value[8] = if is_last { 1 } else { 0 };
+        value[9] = if allowed { 1 } else { 0 };
+        value[10] = if is_wildcard { 1 } else { 0 };
+        value[11] = 0;
 
         map.update(&key, &value, MapFlags::empty())?;
         state = next_state;
@@ -318,18 +322,22 @@ fn add_path_state(map: &libbpf_rs::Map, role_id: u32, pattern: &str, allowed: bo
 
     // Handle directory patterns (ending with /)
     if pattern.ends_with('/') {
-        let mut key = [0u8; 12];
+        let mut key = [0u8; 24];
         key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[4..8].copy_from_slice(&state.to_ne_bytes());
-        key[8..12].copy_from_slice(&0u32.to_ne_bytes());
+        key[8..16].copy_from_slice(&state.to_ne_bytes());
+        key[16..24].copy_from_slice(&0u64.to_ne_bytes());
 
-        let terminal_state: u32 = if allowed { 0xFFFFFFFE } else { 0xFFFFFFFF };
-        let mut value = [0u8; 8];
-        value[0..4].copy_from_slice(&terminal_state.to_ne_bytes());
-        value[4] = 1;
-        value[5] = if allowed { 1 } else { 0 };
-        value[6] = 1;
-        value[7] = 0;
+        let terminal_state: u64 = if allowed {
+            0xFFFF_FFFF_FFFF_FFFE
+        } else {
+            0xFFFF_FFFF_FFFF_FFFF
+        };
+        let mut value = [0u8; 16];
+        value[0..8].copy_from_slice(&terminal_state.to_ne_bytes());
+        value[8] = 1;
+        value[9] = if allowed { 1 } else { 0 };
+        value[10] = 1;
+        value[11] = 0;
 
         map.update(&key, &value, MapFlags::empty())?;
     }
@@ -423,14 +431,6 @@ fn pin_all(object: &mut Object, links: &mut [Link]) -> Result<()> {
 
     log::info!("All BPF objects pinned successfully");
     Ok(())
-}
-
-fn djb2_hash_u32(s: &str) -> u32 {
-    let mut hash: u32 = 5381;
-    for c in s.bytes().take(32) {
-        hash = hash.wrapping_mul(33).wrapping_add(c as u32);
-    }
-    hash
 }
 
 fn flags_to_byte(flags: &bpfjailer_common::types::PolicyFlags) -> u8 {

--- a/bpfjailer-bpf/src/main.bpf.c
+++ b/bpfjailer-bpf/src/main.bpf.c
@@ -81,19 +81,21 @@ struct {
 
 #define MAX_PATH_DEPTH 32       // Max directory depth to walk
 #define PATH_STATE_ROOT 0       // Starting state
-#define PATH_STATE_ACCEPT 0xFFFFFFFE  // Accept (allow)
-#define PATH_STATE_REJECT 0xFFFFFFFF  // Reject (deny)
+// Sentinels live in the same space as the 64-bit state hashes, so they sit at
+// the top of the range where a real FNV-1a digest is vanishingly unlikely.
+#define PATH_STATE_ACCEPT 0xFFFFFFFFFFFFFFFEULL  // Accept (allow)
+#define PATH_STATE_REJECT 0xFFFFFFFFFFFFFFFFULL  // Reject (deny)
 
 // State transition key: current_state + component_hash -> next_state
 struct path_state_key {
     u32 role_id;
-    u32 state;           // Current state
-    u32 component_hash;  // Hash of path component (e.g., "var", "www")
+    u64 state;           // Current state
+    u64 component_hash;  // Hash of path component (e.g., "var", "www")
 };
 
 // State transition value
 struct path_state_value {
-    u32 next_state;      // Next state after this component
+    u64 next_state;      // Next state after this component
     u8 is_terminal;      // 1 if this is a final decision
     u8 decision;         // If terminal: 1=allow, 0=deny
     u8 wildcard;         // 1 if this matches any component (like *)
@@ -212,7 +214,7 @@ struct {
 // Domain rules map: hash of domain -> allowed (1) or blocked (0)
 struct domain_rule_key {
     u32 role_id;
-    u32 domain_hash;  // djb2 hash of domain name
+    u64 domain_hash;  // FNV-1a 64 hash of domain name
 };
 
 struct {
@@ -229,7 +231,7 @@ struct dns_cache_key {
 };
 
 struct dns_cache_value {
-    u32 domain_hash;  // Hash of the domain that resolved to this IP
+    u64 domain_hash;  // Hash of the domain that resolved to this IP
     u64 timestamp;    // When this entry was added (for TTL)
 };
 
@@ -295,8 +297,15 @@ static __always_inline void emit_audit_event(void *ctx, u32 pid, u32 role_id,
 #define MAX_COMPONENTS 16
 #define MAX_COMPONENT_LEN 64
 
+// Bytes of each path component fed into the hash. Must stay in lockstep with
+// the userspace hash in bpfjailer-daemon/src/bpf_loader.rs and
+// bpfjailer-bootstrap/src/main.rs -- both sides must agree byte for byte.
+#define MAX_COMPONENT_HASH_LEN 64
+#define FNV1A64_OFFSET_BASIS 0xcbf29ce484222325ULL
+#define FNV1A64_PRIME        0x00000100000001b3ULL
+
 struct path_components {
-    u32 hashes[MAX_COMPONENTS];  // Hash of each component
+    u64 hashes[MAX_COMPONENTS];  // Hash of each component
     u8 count;                     // Number of components collected
 };
 
@@ -307,21 +316,43 @@ struct {
     __type(value, struct path_components);
 } path_buf SEC(".maps");
 
-// Simple hash for path component (djb2 variant)
-static __always_inline u32 hash_component(const unsigned char *name, u32 len)
+// FNV-1a (64-bit) over the whole component, with the length mixed in.
+//
+// Replaces a 32-bit djb2 that hashed only the first 32 bytes. That combination
+// produced two classes of false-positive policy match:
+//
+//   1. Short collisions from the weak 32-bit mix, e.g. ".ssh" and "01sh" both
+//      hashed to 0x7c784161, as did ".aws" and ".axR".
+//   2. Any two components sharing a 32-byte prefix collided outright, because
+//      everything past byte 32 was discarded.
+//
+// The wider digest addresses (1). Hashing up to MAX_COMPONENT_HASH_LEN bytes
+// and folding in the length addresses (2) for names within that bound.
+//
+// This is still an unkeyed hash, so it resists accidental collisions rather
+// than an attacker computing one offline. See the note in the module docs.
+static __always_inline u64 hash_component(const unsigned char *name, u32 len)
 {
-    u32 hash = 5381;
+    u64 hash = FNV1A64_OFFSET_BASIS;
+    u32 hashed = 0;
 
     #pragma unroll
-    for (int i = 0; i < 32; i++) {
+    for (int i = 0; i < MAX_COMPONENT_HASH_LEN; i++) {
         if (i >= len)
             break;
         unsigned char c = 0;
         bpf_probe_read_kernel(&c, 1, &name[i]);
         if (c == 0)
             break;
-        hash = ((hash << 5) + hash) + c;
+        hash ^= (u64)c;
+        hash *= FNV1A64_PRIME;
+        hashed++;
     }
+
+    // Fold in the byte count so components sharing a prefix but differing in
+    // length cannot alias to the same digest.
+    hash ^= (u64)hashed;
+    hash *= FNV1A64_PRIME;
     return hash;
 }
 

--- a/bpfjailer-common/src/hash.rs
+++ b/bpfjailer-common/src/hash.rs
@@ -1,0 +1,142 @@
+//! Hashing shared by the userspace loaders and the BPF programs.
+//!
+//! The userspace side builds the map keys that the BPF side looks up, so both
+//! must produce identical digests. Keeping one implementation here — rather
+//! than a copy in each loader — removes the obvious way for them to drift.
+
+/// Bytes of each input fed into the hash.
+///
+/// Must equal `MAX_COMPONENT_HASH_LEN` in `bpfjailer-bpf/src/main.bpf.c`.
+pub const MAX_HASH_LEN: usize = 64;
+
+const FNV1A64_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV1A64_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// FNV-1a (64-bit) with the input length folded in.
+///
+/// Must stay byte-for-byte identical to `hash_component()` in
+/// `bpfjailer-bpf/src/main.bpf.c`.
+///
+/// This replaced a 32-bit djb2 that hashed only the first 32 bytes. That
+/// combination produced two classes of false-positive policy match:
+///
+/// 1. Short collisions from the weak 32-bit mix — `".ssh"` and `"01sh"` both
+///    hashed to `0x7c784161`, as did `".aws"` and `".axR"`.
+/// 2. Any two inputs sharing a 32-byte prefix collided outright, because
+///    everything past byte 32 was discarded.
+///
+/// The wider digest addresses (1); hashing up to [`MAX_HASH_LEN`] bytes and
+/// folding in the length addresses (2) for inputs within that bound.
+///
+/// # Limitations
+///
+/// This is an unkeyed hash. It resists *accidental* collisions; it does not
+/// stop someone computing a collision offline and naming a file to match. A
+/// keyed construction (SipHash with a per-boot key), or verifying the
+/// component string after a hash hit, would be needed for that.
+///
+/// Inputs longer than [`MAX_HASH_LEN`] bytes are still truncated, so two names
+/// sharing a 64-byte prefix *and* of equal length collide.
+pub fn fnv1a_hash_u64(s: &str) -> u64 {
+    let mut hash = FNV1A64_OFFSET_BASIS;
+    let mut hashed: u64 = 0;
+    for c in s.bytes().take(MAX_HASH_LEN) {
+        hash ^= c as u64;
+        hash = hash.wrapping_mul(FNV1A64_PRIME);
+        hashed += 1;
+    }
+    hash ^= hashed;
+    hash.wrapping_mul(FNV1A64_PRIME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The collisions reported in issue #21 against the old djb2 hash.
+    #[test]
+    fn reported_djb2_collisions_no_longer_collide() {
+        for (a, b) in [(".ssh", "01sh"), (".aws", ".axR")] {
+            assert_eq!(djb2_u32(a), djb2_u32(b), "precondition: old hash collided");
+            assert_ne!(
+                fnv1a_hash_u64(a),
+                fnv1a_hash_u64(b),
+                "{a:?} and {b:?} still collide"
+            );
+        }
+    }
+
+    /// The old hash read only 32 bytes, so anything sharing a 32-byte prefix
+    /// collided regardless of what followed.
+    #[test]
+    fn shared_prefix_no_longer_collides_within_bound() {
+        let a = format!("{}SECRET", "a".repeat(32));
+        let b = format!("{}public", "a".repeat(32));
+        assert_eq!(
+            djb2_u32(&a),
+            djb2_u32(&b),
+            "precondition: old hash collided"
+        );
+        assert_ne!(fnv1a_hash_u64(&a), fnv1a_hash_u64(&b));
+    }
+
+    /// Length is folded in, so a prefix cannot alias its own extension.
+    #[test]
+    fn length_is_mixed_in() {
+        assert_ne!(fnv1a_hash_u64("etc"), fnv1a_hash_u64("etcd"));
+        assert_ne!(fnv1a_hash_u64(""), fnv1a_hash_u64("\0"));
+    }
+
+    #[test]
+    fn is_deterministic() {
+        assert_eq!(fnv1a_hash_u64("/etc/shadow"), fnv1a_hash_u64("/etc/shadow"));
+    }
+
+    /// Known-answer test. If this changes, the BPF side must change with it or
+    /// every policy silently stops matching.
+    #[test]
+    fn known_answers_pin_the_algorithm() {
+        assert_eq!(fnv1a_hash_u64(""), 0xaf63_bd4c_8601_b7df);
+        assert_eq!(fnv1a_hash_u64("etc"), 0xc441_4a60_7a45_4d4a);
+        assert_eq!(fnv1a_hash_u64(".ssh"), 0xd05a_cb17_0a18_12d3);
+        assert_eq!(fnv1a_hash_u64("/etc/shadow"), 0x994e_56fe_b673_6f3a);
+        // Cross-check against an independent restatement of the algorithm.
+        for s in ["", "etc", ".ssh", "/etc/shadow"] {
+            assert_eq!(fnv1a_hash_u64(s), fnv1a_reference(s), "mismatch for {s:?}");
+        }
+    }
+
+    /// Beyond MAX_HASH_LEN the input is truncated -- documented, not fixed.
+    #[test]
+    fn documents_truncation_beyond_bound() {
+        let a = format!("{}X", "b".repeat(MAX_HASH_LEN));
+        let b = format!("{}Y", "b".repeat(MAX_HASH_LEN));
+        assert_eq!(
+            fnv1a_hash_u64(&a),
+            fnv1a_hash_u64(&b),
+            "inputs past MAX_HASH_LEN are truncated; see fn docs"
+        );
+    }
+
+    /// Independent restatement of the algorithm, so the test does not simply
+    /// mirror the implementation it is checking.
+    fn fnv1a_reference(s: &str) -> u64 {
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        let mut n: u64 = 0;
+        for b in s.as_bytes().iter().take(64) {
+            h = (h ^ *b as u64).wrapping_mul(0x100_0000_01b3);
+            n += 1;
+        }
+        (h ^ n).wrapping_mul(0x100_0000_01b3)
+    }
+
+    /// The hash this replaced, kept only so the tests above can assert the
+    /// collisions were real.
+    fn djb2_u32(s: &str) -> u32 {
+        let mut h: u32 = 5381;
+        for c in s.bytes().take(32) {
+            h = h.wrapping_mul(33).wrapping_add(c as u32);
+        }
+        h
+    }
+}

--- a/bpfjailer-common/src/lib.rs
+++ b/bpfjailer-common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod hash;
 pub mod policy;
 pub mod types;
 

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -319,7 +319,7 @@ impl BpfJailerBpf {
             .map("path_rules")
             .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
 
-        let path_hash = djb2_hash(path);
+        let path_hash = bpfjailer_common::hash::fnv1a_hash_u64(path);
 
         // struct path_rule_key { u32 role_id; u64 path_hash; }
         let mut key = [0u8; 16]; // 4 + 4 padding + 8 = 16 bytes
@@ -350,7 +350,7 @@ impl BpfJailerBpf {
             .map("path_rules")
             .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
 
-        let path_hash = djb2_hash(path);
+        let path_hash = bpfjailer_common::hash::fnv1a_hash_u64(path);
 
         let mut key = [0u8; 16];
         key[0..4].copy_from_slice(&role_id.to_ne_bytes());
@@ -382,7 +382,7 @@ impl BpfJailerBpf {
             return Ok(());
         }
 
-        let mut state: u32 = 0; // Start from root state
+        let mut state: u64 = 0; // Start from root state
 
         for (i, component) in components.iter().enumerate() {
             let is_last = i == components.len() - 1;
@@ -390,34 +390,38 @@ impl BpfJailerBpf {
             let component_hash = if is_wildcard {
                 0
             } else {
-                djb2_hash_u32(component)
+                bpfjailer_common::hash::fnv1a_hash_u64(component)
             };
 
             // Create state transition
             // struct path_state_key { u32 role_id; u32 state; u32 component_hash; }
-            let mut key = [0u8; 12];
+            let mut key = [0u8; 24];
             key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-            key[4..8].copy_from_slice(&state.to_ne_bytes());
-            key[8..12].copy_from_slice(&component_hash.to_ne_bytes());
+            key[8..16].copy_from_slice(&state.to_ne_bytes());
+            key[16..24].copy_from_slice(&component_hash.to_ne_bytes());
 
             let next_state = if is_last {
                 if allowed {
-                    0xFFFFFFFE
+                    0xFFFF_FFFF_FFFF_FFFE_u64
                 } else {
-                    0xFFFFFFFF
+                    0xFFFF_FFFF_FFFF_FFFF_u64
                 } // ACCEPT or REJECT
             } else {
                 // Generate unique state ID based on path so far
-                djb2_hash_u32(&format!("{}:{}", role_id, components[..=i].join("/")))
+                bpfjailer_common::hash::fnv1a_hash_u64(&format!(
+                    "{}:{}",
+                    role_id,
+                    components[..=i].join("/")
+                ))
             };
 
             // struct path_state_value { u32 next_state; u8 is_terminal; u8 decision; u8 wildcard; u8 _pad; }
-            let mut value = [0u8; 8];
-            value[0..4].copy_from_slice(&next_state.to_ne_bytes());
-            value[4] = if is_last { 1 } else { 0 }; // is_terminal
-            value[5] = if allowed { 1 } else { 0 }; // decision
-            value[6] = if is_wildcard { 1 } else { 0 }; // wildcard
-            value[7] = 0; // padding
+            let mut value = [0u8; 16];
+            value[0..8].copy_from_slice(&next_state.to_ne_bytes());
+            value[8] = if is_last { 1 } else { 0 }; // is_terminal
+            value[9] = if allowed { 1 } else { 0 }; // decision
+            value[10] = if is_wildcard { 1 } else { 0 }; // wildcard
+            value[11] = 0; // padding
 
             map.update(&key, &value, MapFlags::empty())?;
 
@@ -427,18 +431,22 @@ impl BpfJailerBpf {
         // If pattern ends with "/" (directory), add terminal state for any file under it
         if pattern.ends_with('/') {
             // Add wildcard transition for any component after this directory
-            let mut key = [0u8; 12];
+            let mut key = [0u8; 24];
             key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-            key[4..8].copy_from_slice(&state.to_ne_bytes());
-            key[8..12].copy_from_slice(&0u32.to_ne_bytes()); // wildcard (0 = any)
+            key[8..16].copy_from_slice(&state.to_ne_bytes());
+            key[16..24].copy_from_slice(&0u64.to_ne_bytes()); // wildcard (0 = any)
 
-            let terminal_state: u32 = if allowed { 0xFFFFFFFE } else { 0xFFFFFFFF };
-            let mut value = [0u8; 8];
-            value[0..4].copy_from_slice(&terminal_state.to_ne_bytes());
-            value[4] = 1; // is_terminal
-            value[5] = if allowed { 1 } else { 0 };
-            value[6] = 1; // wildcard
-            value[7] = 0;
+            let terminal_state: u64 = if allowed {
+                0xFFFF_FFFF_FFFF_FFFE
+            } else {
+                0xFFFF_FFFF_FFFF_FFFF
+            };
+            let mut value = [0u8; 16];
+            value[0..8].copy_from_slice(&terminal_state.to_ne_bytes());
+            value[8] = 1; // is_terminal
+            value[9] = if allowed { 1 } else { 0 };
+            value[10] = 1; // wildcard
+            value[11] = 0;
 
             map.update(&key, &value, MapFlags::empty())?;
         }
@@ -454,7 +462,11 @@ impl BpfJailerBpf {
 
         // Debug: show component hashes
         for (i, comp) in components.iter().enumerate() {
-            let h = if *comp == "*" { 0 } else { djb2_hash_u32(comp) };
+            let h = if *comp == "*" {
+                0
+            } else {
+                bpfjailer_common::hash::fnv1a_hash_u64(comp)
+            };
             log::debug!("  Component {}: \"{}\" -> hash={:#x}", i, comp, h);
         }
 
@@ -753,12 +765,12 @@ impl BpfJailerBpf {
             .map("domain_rules")
             .ok_or_else(|| anyhow::anyhow!("domain_rules map not found"))?;
 
-        let domain_hash = djb2_hash_u32(domain);
+        let domain_hash = bpfjailer_common::hash::fnv1a_hash_u64(domain);
 
-        // struct domain_rule_key { u32 role_id; u32 domain_hash; }
-        let mut key = [0u8; 8];
+        // struct domain_rule_key { u32 role_id; u64 domain_hash; }  (4B padding)
+        let mut key = [0u8; 16];
         key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[4..8].copy_from_slice(&domain_hash.to_ne_bytes());
+        key[8..16].copy_from_slice(&domain_hash.to_ne_bytes());
 
         let value = [if allowed { 1u8 } else { 0u8 }];
         map.update(&key, &value, MapFlags::empty())?;
@@ -783,11 +795,11 @@ impl BpfJailerBpf {
             .map("domain_rules")
             .ok_or_else(|| anyhow::anyhow!("domain_rules map not found"))?;
 
-        let domain_hash = djb2_hash_u32(domain);
+        let domain_hash = bpfjailer_common::hash::fnv1a_hash_u64(domain);
 
-        let mut key = [0u8; 8];
+        let mut key = [0u8; 16];
         key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[4..8].copy_from_slice(&domain_hash.to_ne_bytes());
+        key[8..16].copy_from_slice(&domain_hash.to_ne_bytes());
 
         map.delete(&key)?;
         log::info!("Removed domain rule: role={} {}", role_id, domain);
@@ -927,22 +939,4 @@ impl BpfJailerBpf {
         log::info!("Pinned BPF objects removed (programs still active until reboot)");
         Ok(())
     }
-}
-
-/// djb2 hash function (64-bit) - must match the BPF implementation exactly
-fn djb2_hash(s: &str) -> u64 {
-    let mut hash: u64 = 5381;
-    for c in s.bytes().take(64) {
-        hash = hash.wrapping_mul(33).wrapping_add(c as u64);
-    }
-    hash
-}
-
-/// djb2 hash function (32-bit) - for path component hashing
-fn djb2_hash_u32(s: &str) -> u32 {
-    let mut hash: u32 = 5381;
-    for c in s.bytes().take(32) {
-        hash = hash.wrapping_mul(33).wrapping_add(c as u32);
-    }
-    hash
 }


### PR DESCRIPTION
Fixes #21.

## Problem

`hash_component()` used a 32-bit djb2 that read only the first 32 bytes of each
path component. That produced two classes of false-positive policy match — a
component could satisfy a rule written for a different path.

**1. Weak 32-bit mix.** The collisions reported in the issue reproduce exactly:

| input | djb2 |
|---|---|
| `.ssh` | `0x7c784161` |
| `01sh` | `0x7c784161` |
| `.aws` | `0x7c77f55e` |
| `.axR` | `0x7c77f55e` |

**2. Truncation at 32 bytes.** Everything past byte 32 was discarded, so *any*
two components sharing a 32-byte prefix collided:

```
"a"*32 + "SECRET"  ->  0x2d5bf325
"a"*32 + "public"  ->  0x2d5bf325
```

The second is the easier one to hit deliberately, since it needs no search.

## Changes

- **FNV-1a 64** over up to 64 bytes, with the byte count folded in so a prefix
  cannot alias its own extension.
- **`component_hash` widened to `u64`** in `path_state_key` and in the userspace
  key packing.
- **`state`/`next_state` widened to `u64`.** The state id is itself
  `hash(role_id + ":" + path_prefix)`, so leaving it 32-bit would have preserved
  the same collision class one level up — two different prefixes sharing a DFA
  state. Sentinels moved to `0xFFFF_FFFF_FFFF_FFFE/F`.
- **Hash moved into `bpfjailer-common`.** It was duplicated in the daemon and
  the bootstrap. Userspace builds the keys the BPF side looks up, so any
  divergence silently stops policies matching; one copy removes that risk.
- **Same hash applied to `domain_rules`** and the legacy `path_rules` map, so no
  weak copy is left behind.

## Tests

Six unit tests in `bpfjailer-common::hash` — the repo previously had none.
They cover the reported collisions, the shared-prefix class, length mixing,
determinism, known answers pinning the algorithm, and an explicit test
documenting that inputs past 64 bytes still truncate.

## Verification

**Userspace and BPF agree.** The C hash was compiled standalone and compared
against the Rust implementation:

| input | C | Rust |
|---|---|---|
| `""` | `0xaf63bd4c8601b7df` | same |
| `"etc"` | `0xc4414a607a454d4a` | same |
| `".ssh"` | `0xd05acb170a1812d3` | same |
| `"/etc/shadow"` | `0x994e56feb6736f3a` | same |

And the reported pairs now differ: `.ssh` `0xd05a…` vs `01sh` `0xa6d1…`,
`.aws` `0x6bc4…` vs `.axR` `0x7624…`.

**The BPF program still verifies and loads** — checked on a 6.18 kernel with
`CONFIG_BPF_LSM=y` and `bpf` in the active LSM list. `bpfjailer-bootstrap` pins
all 11 LSM programs with no verifier complaints, which was the main risk given
the widened structs.

**The path state machine still enforces**, exercised end to end against a role
with `allow_file_access: true` and an explicit deny for `/etc/hostname`:

| case | result |
|---|---|
| enrolled binary reads `/etc/hostname` (denied) | blocked |
| enrolled binary reads `/etc/os-release` (no rule) | allowed |
| unenrolled binary reads `/etc/hostname` | allowed |

That path exercises the new hash on both sides, so it confirms the two
implementations agree in the kernel rather than only in a test harness.

`fmt`, `clippy -D warnings`, `doc -D warnings`, `machete`, tests and release
build all pass.

## What this does not fix

FNV-1a is **unkeyed**. It resists accidental collisions; it does not stop
someone computing a collision offline and naming a file to match. Inputs longer
than 64 bytes are still truncated, so two names sharing a 64-byte prefix *and*
of equal length still collide.

Closing those needs one of the approaches @JackySu suggested — a keyed hash
(SipHash with a per-boot key), or verifying the component string after a hash
hit. Both are larger changes and worth doing separately; this PR removes the
trivially-reachable collisions first. Both limits are documented on the
function rather than left implicit.
