### PR TITLE
Pack all role flags in the daemon, not just the first three

### DIFF
--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -149,7 +149,7 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
     // Load roles and their flags
     for (name, role) in &policy.roles {
         let role_id = role.id.0;
-        let flags = flags_to_byte(&role.flags);
+        let flags = bpfjailer_common::flags::policy_flags_to_u8(&role.flags);
 
         // Update role_flags map
         if let Some(map) = object.map("role_flags") {
@@ -431,33 +431,4 @@ fn pin_all(object: &mut Object, links: &mut [Link]) -> Result<()> {
 
     log::info!("All BPF objects pinned successfully");
     Ok(())
-}
-
-fn flags_to_byte(flags: &bpfjailer_common::types::PolicyFlags) -> u8 {
-    let mut byte: u8 = 0;
-    if flags.allow_file_access {
-        byte |= 0x01;
-    }
-    if flags.allow_network {
-        byte |= 0x02;
-    }
-    if flags.allow_exec {
-        byte |= 0x04;
-    }
-    if flags.require_signed_binary {
-        byte |= 0x08;
-    }
-    if flags.allow_setuid {
-        byte |= 0x10;
-    }
-    if flags.allow_ptrace {
-        byte |= 0x20;
-    }
-    if flags.allow_module_load {
-        byte |= 0x40;
-    }
-    if flags.allow_bpf_load {
-        byte |= 0x80;
-    }
-    byte
 }

--- a/bpfjailer-common/src/flags.rs
+++ b/bpfjailer-common/src/flags.rs
@@ -1,0 +1,158 @@
+//! Packing of [`PolicyFlags`] into the single byte stored in the BPF
+//! `role_flags` map.
+//!
+//! The BPF programs test individual bits of this byte to decide whether an
+//! operation is permitted, so the bit assignment here is the contract between
+//! userspace and `bpfjailer-bpf/src/main.bpf.c`.
+
+use crate::types::PolicyFlags;
+
+/// Bit assignments checked by the BPF programs.
+pub const FLAG_ALLOW_FILE_ACCESS: u8 = 0x01;
+pub const FLAG_ALLOW_NETWORK: u8 = 0x02;
+pub const FLAG_ALLOW_EXEC: u8 = 0x04;
+pub const FLAG_REQUIRE_SIGNED_BINARY: u8 = 0x08;
+pub const FLAG_ALLOW_SETUID: u8 = 0x10;
+pub const FLAG_ALLOW_PTRACE: u8 = 0x20;
+pub const FLAG_ALLOW_MODULE_LOAD: u8 = 0x40;
+pub const FLAG_ALLOW_BPF_LOAD: u8 = 0x80;
+
+/// Pack [`PolicyFlags`] into the byte the BPF `role_flags` map stores.
+///
+/// `require_proxy` is deliberately absent: all eight bits are taken, and the
+/// BPF side reads that setting from `proxy_config` instead.
+pub fn policy_flags_to_u8(flags: &PolicyFlags) -> u8 {
+    let mut byte = 0u8;
+    if flags.allow_file_access {
+        byte |= FLAG_ALLOW_FILE_ACCESS;
+    }
+    if flags.allow_network {
+        byte |= FLAG_ALLOW_NETWORK;
+    }
+    if flags.allow_exec {
+        byte |= FLAG_ALLOW_EXEC;
+    }
+    if flags.require_signed_binary {
+        byte |= FLAG_REQUIRE_SIGNED_BINARY;
+    }
+    if flags.allow_setuid {
+        byte |= FLAG_ALLOW_SETUID;
+    }
+    if flags.allow_ptrace {
+        byte |= FLAG_ALLOW_PTRACE;
+    }
+    if flags.allow_module_load {
+        byte |= FLAG_ALLOW_MODULE_LOAD;
+    }
+    if flags.allow_bpf_load {
+        byte |= FLAG_ALLOW_BPF_LOAD;
+    }
+    byte
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn none() -> PolicyFlags {
+        PolicyFlags::default()
+    }
+
+    fn all() -> PolicyFlags {
+        PolicyFlags {
+            allow_file_access: true,
+            allow_network: true,
+            allow_exec: true,
+            require_signed_binary: true,
+            allow_setuid: true,
+            allow_ptrace: true,
+            allow_module_load: true,
+            allow_bpf_load: true,
+            require_proxy: true,
+        }
+    }
+
+    #[test]
+    fn no_flags_packs_to_zero() {
+        assert_eq!(policy_flags_to_u8(&none()), 0);
+    }
+
+    /// Every flag must reach the byte. The daemon previously packed only the
+    /// first three, so a role granting ptrace, module load or BPF load was
+    /// silently enforced as if it did not.
+    #[test]
+    fn every_flag_reaches_the_byte() {
+        assert_eq!(policy_flags_to_u8(&all()), 0xFF);
+    }
+
+    /// Each flag must land on the bit the BPF programs actually test.
+    /// Sets one field on a PolicyFlags, paired with the bit it must produce.
+    type FlagCase = (fn(&mut PolicyFlags), u8);
+
+    #[test]
+    fn each_flag_maps_to_its_documented_bit() {
+        let cases: [FlagCase; 8] = [
+            (|f| f.allow_file_access = true, FLAG_ALLOW_FILE_ACCESS),
+            (|f| f.allow_network = true, FLAG_ALLOW_NETWORK),
+            (|f| f.allow_exec = true, FLAG_ALLOW_EXEC),
+            (
+                |f| f.require_signed_binary = true,
+                FLAG_REQUIRE_SIGNED_BINARY,
+            ),
+            (|f| f.allow_setuid = true, FLAG_ALLOW_SETUID),
+            (|f| f.allow_ptrace = true, FLAG_ALLOW_PTRACE),
+            (|f| f.allow_module_load = true, FLAG_ALLOW_MODULE_LOAD),
+            (|f| f.allow_bpf_load = true, FLAG_ALLOW_BPF_LOAD),
+        ];
+        for (set, expected_bit) in cases {
+            let mut f = none();
+            set(&mut f);
+            assert_eq!(
+                policy_flags_to_u8(&f),
+                expected_bit,
+                "flag should set exactly bit {expected_bit:#04x}"
+            );
+        }
+    }
+
+    /// The bit constants must be distinct and cover the byte, or two
+    /// permissions would alias onto one bit.
+    #[test]
+    fn bits_are_distinct_and_cover_the_byte() {
+        let bits = [
+            FLAG_ALLOW_FILE_ACCESS,
+            FLAG_ALLOW_NETWORK,
+            FLAG_ALLOW_EXEC,
+            FLAG_REQUIRE_SIGNED_BINARY,
+            FLAG_ALLOW_SETUID,
+            FLAG_ALLOW_PTRACE,
+            FLAG_ALLOW_MODULE_LOAD,
+            FLAG_ALLOW_BPF_LOAD,
+        ];
+        let mut seen = 0u8;
+        for b in bits {
+            assert_eq!(b.count_ones(), 1, "{b:#04x} must be a single bit");
+            assert_eq!(seen & b, 0, "{b:#04x} collides with another flag");
+            seen |= b;
+        }
+        assert_eq!(seen, 0xFF, "all eight bits must be assigned");
+    }
+
+    /// require_proxy has no bit -- all eight are taken and BPF reads it from
+    /// proxy_config. Setting it alone must not disturb the byte.
+    #[test]
+    fn require_proxy_is_not_packed() {
+        let mut f = none();
+        f.require_proxy = true;
+        assert_eq!(policy_flags_to_u8(&f), 0);
+    }
+
+    /// Guards the specific regression: a role that only grants ptrace must not
+    /// pack to the same byte as a role that grants nothing.
+    #[test]
+    fn ptrace_only_role_is_distinguishable_from_empty_role() {
+        let mut f = none();
+        f.allow_ptrace = true;
+        assert_ne!(policy_flags_to_u8(&f), policy_flags_to_u8(&none()));
+    }
+}

--- a/bpfjailer-common/src/lib.rs
+++ b/bpfjailer-common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod flags;
 pub mod hash;
 pub mod policy;
 pub mod types;

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -18,23 +18,7 @@ pub struct ProcessTracker {
     bpf: Arc<BpfJailerBpf>,
 }
 
-// Convert PolicyFlags to u8 for BPF map
-// bit 0 (0x01) = allow_file_access
-// bit 1 (0x02) = allow_network
-// bit 2 (0x04) = allow_exec
-fn policy_flags_to_u8(flags: &PolicyFlags) -> u8 {
-    let mut result = 0u8;
-    if flags.allow_file_access {
-        result |= 0x01;
-    }
-    if flags.allow_network {
-        result |= 0x02;
-    }
-    if flags.allow_exec {
-        result |= 0x04;
-    }
-    result
-}
+use bpfjailer_common::flags::policy_flags_to_u8;
 
 impl ProcessTracker {
     pub fn new(bpf: Arc<BpfJailerBpf>) -> Result<Self> {


### PR DESCRIPTION
## Problem

The daemon and the bootstrap each carried their own `PolicyFlags -> u8` packer,
and they disagreed:

| | bits packed |
|---|---|
| `bootstrap::flags_to_byte` | all eight, `0x01`..`0x80` |
| `daemon::policy_flags_to_u8` | **only `0x01`, `0x02`, `0x04`** |

A process enrolled by the daemon therefore silently lost
`require_signed_binary`, `allow_setuid`, `allow_ptrace`, `allow_module_load`
and `allow_bpf_load`.

Those bits are not decorative — the BPF programs test them directly:

```c
main.bpf.c:1062   if (!(*flags & 0x20))   // allow_ptrace
main.bpf.c:1094   if (!(*flags & 0x40))   // allow_module_load
main.bpf.c:1125   if (!(*flags & 0x80))   // allow_bpf_load
```

So a role granting ptrace, module load or BPF load was enforced as though it
did not, and `allow_setuid` was always off — which breaks any service that
drops privileges, `sshd` being the obvious one.

The practical consequence: **the same policy produced different enforcement
depending on whether it was applied by the daemon or by the daemonless
bootstrap.** It fails closed rather than open, so it denies rather than
permits, but it is still silently not the policy that was written.

## Changes

- New `bpfjailer-common::flags` with named bit constants (`FLAG_ALLOW_PTRACE`
  etc.) and a single `policy_flags_to_u8`.
- Both callers now use it; the two local copies are deleted.

Two copies of a security-critical bit mapping is what allowed them to drift,
so the fix is consolidation rather than patching the daemon's copy.

`require_proxy` remains unpacked, and there is a test asserting that: all eight
bits are taken, and the BPF side reads that setting from `proxy_config`.

## Tests

Written test-first — the implementation was stubbed with `unimplemented!()`,
the tests were run to confirm they failed for the right reason, then the packer
was written to satisfy them:

- `every_flag_reaches_the_byte` — all flags set must give `0xFF`. This is the
  case the daemon failed; it produced `0x07`.
- `each_flag_maps_to_its_documented_bit` — each flag lands on the bit BPF tests.
- `bits_are_distinct_and_cover_the_byte` — no two permissions alias.
- `require_proxy_is_not_packed` — documents the deliberate omission.
- `ptrace_only_role_is_distinguishable_from_empty_role` — the specific
  regression.
- `no_flags_packs_to_zero`.

## Verification

`fmt`, `clippy -D warnings`, `doc -D warnings`, `machete`, 12 workspace tests
and the release build all pass.

Bootstrap enforcement was re-checked end to end on a 6.18 kernel after the
refactor, since its packer changed too — a role with `allow_network: false` and
`allow_file_access: true` still blocks network and permits file access, while an
unenrolled process is unaffected.

The daemon path is covered by unit tests rather than a live run; the appliance
this was checked on uses daemonless mode.
