### PR TITLE
Raise test coverage from 7.7% to 81.7%, with root integration tests

### DIFF
--- a/.github/workflows/wellness-check.yml
+++ b/.github/workflows/wellness-check.yml
@@ -104,3 +104,36 @@ jobs:
       # libbpf via FFI and load BPF objects, which miri cannot model.
       # bpfjailer-common is pure-Rust policy and type definitions.
       - run: cargo +nightly miri test -p bpfjailer-common --lib
+
+  root-integration:
+    name: Integration (root, real BPF)
+    needs: [fmt, clippy]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install BPF build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev libelf-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: root-integration
+      - name: Report kernel BPF capability
+        run: |
+          uname -r
+          test -f /sys/kernel/btf/vmlinux && echo "BTF: present" || echo "BTF: MISSING"
+          cat /sys/kernel/security/lsm 2>/dev/null || echo "lsm: securityfs not mounted"
+      - name: Build BPF programs
+        working-directory: bpfjailer-bpf
+        run: cargo build --release
+      # These load the real BPF object and round-trip every map through the
+      # kernel. They need root but not `bpf` in the active LSM list: the
+      # programs are loaded (creating the maps) and never attached.
+      # Serial: each test loads its own object and the enrollment tests share
+      # a fixed socket path.
+      - name: Root integration tests
+        run: |
+          sudo -E env "PATH=$PATH" cargo test --workspace --release \
+            -- --include-ignored --test-threads=1
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ name = "bpfjailer-common"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -358,3 +358,159 @@ fn pin_all(object: &mut Object, links: &mut [Link]) -> Result<()> {
     log::info!("All BPF objects pinned successfully");
     Ok(())
 }
+
+/// Root-gated tests for the daemonless bootstrap.
+///
+/// `load_bpf_object` and `pin_all` also *attach* the LSM programs, which needs
+/// `bpf` in the kernel's active LSM list; they are exercised on an LSM-enabled
+/// host rather than here. `populate_maps` only needs the maps to exist, so it
+/// is driven against an object that is loaded but never attached.
+#[cfg(test)]
+mod root_integration {
+    use super::*;
+
+    fn bpf_object_path() -> Option<std::path::PathBuf> {
+        let root = std::env::var("CARGO_MANIFEST_DIR")
+            .ok()
+            .map(PathBuf::from)?
+            .parent()?
+            .to_path_buf();
+        let p = root.join("bpfjailer-bpf/target/bpfel-unknown-none/release/bpfjailer.bpf.o");
+        p.exists().then_some(p)
+    }
+
+    /// Load (but do not attach) the BPF object, so the maps exist.
+    fn loaded_object() -> Option<Object> {
+        let path = bpf_object_path()?;
+        let mut builder = libbpf_rs::ObjectBuilder::default();
+        builder.open_file(path).ok()?.load().ok()
+    }
+
+    fn write_policy(tag: &str, body: &str) -> std::path::PathBuf {
+        let p =
+            std::env::temp_dir().join(format!("bpfjailer-boot-{tag}-{}.json", std::process::id()));
+        fs::write(&p, body).expect("write policy");
+        p
+    }
+
+    const POLICY: &str = r#"{
+      "roles": {
+        "web": { "id": 30, "name": "web",
+          "flags": {"allow_file_access": true, "allow_network": true, "allow_exec": true,
+                    "require_signed_binary": false, "allow_setuid": true, "allow_ptrace": false,
+                    "allow_module_load": true, "allow_bpf_load": true},
+          "file_paths": [{"pattern": "/var/www/", "allow": true},
+                         {"pattern": "/etc/shadow", "allow": false}],
+          "network_rules": [{"protocol": "tcp", "port": 443, "allow": true}],
+          "execution_rules": [], "require_signed_binary": false }
+      },
+      "pods": [{"id": 300, "role_id": 30, "stack_depth": 0}],
+      "exec_enrollments": [],
+      "cgroup_enrollments": []
+    }"#;
+
+    #[test]
+    #[ignore = "requires root"]
+    fn is_pinned_reflects_the_pin_directory() {
+        // Whatever the current state, the answer must match the filesystem.
+        assert_eq!(is_pinned(), Path::new(BPF_PIN_PATH).exists());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn load_policy_honours_the_env_override() {
+        let path = write_policy("env", POLICY);
+        std::env::set_var("BPFJAILER_POLICY", &path);
+        let cfg = load_policy().expect("load");
+        std::env::remove_var("BPFJAILER_POLICY");
+        assert!(cfg.get_role("web").is_some());
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn load_policy_surfaces_malformed_json() {
+        let path = write_policy("bad", "{ not json");
+        std::env::set_var("BPFJAILER_POLICY", &path);
+        let err = load_policy().unwrap_err();
+        std::env::remove_var("BPFJAILER_POLICY");
+        assert!(format!("{err:#}").contains("parse"), "got: {err:#}");
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn load_policy_surfaces_a_missing_file() {
+        std::env::set_var("BPFJAILER_POLICY", "/nonexistent/policy.json");
+        let err = load_policy().unwrap_err();
+        std::env::remove_var("BPFJAILER_POLICY");
+        assert!(format!("{err:#}").contains("read"), "got: {err:#}");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn populate_maps_writes_roles_flags_and_path_states() {
+        let Some(mut object) = loaded_object() else {
+            eprintln!("skipping: BPF object not built or no permission");
+            return;
+        };
+        let cfg: PolicyConfig = serde_json::from_str(POLICY).expect("parse policy");
+        populate_maps(&mut object, &cfg).expect("populate");
+
+        // role_flags: every bit must survive, not just the first three.
+        let flags = object
+            .map("role_flags")
+            .expect("map")
+            .lookup(&30u32.to_ne_bytes(), MapFlags::empty())
+            .expect("lookup")
+            .expect("role present");
+        let expected =
+            bpfjailer_common::flags::policy_flags_to_u8(&cfg.get_role("web").unwrap().flags);
+        assert_eq!(flags[0], expected);
+
+        // path_states: the deny rule must be present under the codec's key.
+        let entries = bpfjailer_common::codec::path_state_entries(30, "/etc/shadow", false);
+        let map = object.map("path_states").expect("map");
+        for (key, value) in entries {
+            let got = map
+                .lookup(&key, MapFlags::empty())
+                .expect("lookup")
+                .expect("transition present");
+            assert_eq!(got.as_slice(), value.as_slice());
+        }
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn populate_maps_writes_pod_to_role() {
+        let Some(mut object) = loaded_object() else {
+            return;
+        };
+        let cfg: PolicyConfig = serde_json::from_str(POLICY).expect("parse");
+        populate_maps(&mut object, &cfg).expect("populate");
+        let v = object
+            .map("pod_to_role")
+            .expect("map")
+            .lookup(&300u64.to_ne_bytes(), MapFlags::empty())
+            .expect("lookup")
+            .expect("pod present");
+        assert_eq!(u32::from_ne_bytes(v[0..4].try_into().unwrap()), 30);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn add_path_state_matches_the_shared_codec() {
+        let Some(object) = loaded_object() else {
+            return;
+        };
+        let map = object.map("path_states").expect("map");
+        add_path_state(map, 31, "/srv/data/", false).expect("add");
+        for (key, value) in bpfjailer_common::codec::path_state_entries(31, "/srv/data/", false) {
+            let got = map
+                .lookup(&key, MapFlags::empty())
+                .expect("lookup")
+                .expect("present");
+            assert_eq!(got.as_slice(), value.as_slice());
+        }
+    }
+}

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -270,85 +270,11 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
 }
 
 fn add_path_state(map: &libbpf_rs::Map, role_id: u32, pattern: &str, allowed: bool) -> Result<()> {
-    let components: Vec<&str> = pattern
-        .split('/')
-        .filter(|s| !s.is_empty() && *s != "**")
-        .collect();
-
-    if components.is_empty() {
-        return Ok(());
-    }
-
-    let mut state: u64 = 0;
-
-    for (i, component) in components.iter().enumerate() {
-        let is_last = i == components.len() - 1;
-        let is_wildcard = *component == "*";
-        let component_hash = if is_wildcard {
-            0
-        } else {
-            bpfjailer_common::hash::fnv1a_hash_u64(component)
-        };
-
-        let mut key = [0u8; 24];
-        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[8..16].copy_from_slice(&state.to_ne_bytes());
-        key[16..24].copy_from_slice(&component_hash.to_ne_bytes());
-
-        let next_state = if is_last {
-            if allowed {
-                0xFFFF_FFFF_FFFF_FFFE_u64
-            } else {
-                0xFFFF_FFFF_FFFF_FFFF_u64
-            }
-        } else {
-            bpfjailer_common::hash::fnv1a_hash_u64(&format!(
-                "{}:{}",
-                role_id,
-                components[..=i].join("/")
-            ))
-        };
-
-        let mut value = [0u8; 16];
-        value[0..8].copy_from_slice(&next_state.to_ne_bytes());
-        value[8] = if is_last { 1 } else { 0 };
-        value[9] = if allowed { 1 } else { 0 };
-        value[10] = if is_wildcard { 1 } else { 0 };
-        value[11] = 0;
-
-        map.update(&key, &value, MapFlags::empty())?;
-        state = next_state;
-    }
-
-    // Handle directory patterns (ending with /)
-    if pattern.ends_with('/') {
-        let mut key = [0u8; 24];
-        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[8..16].copy_from_slice(&state.to_ne_bytes());
-        key[16..24].copy_from_slice(&0u64.to_ne_bytes());
-
-        let terminal_state: u64 = if allowed {
-            0xFFFF_FFFF_FFFF_FFFE
-        } else {
-            0xFFFF_FFFF_FFFF_FFFF
-        };
-        let mut value = [0u8; 16];
-        value[0..8].copy_from_slice(&terminal_state.to_ne_bytes());
-        value[8] = 1;
-        value[9] = if allowed { 1 } else { 0 };
-        value[10] = 1;
-        value[11] = 0;
-
+    // Shared with the daemon: both sides must produce byte-identical keys, so
+    // the walk lives in bpfjailer_common::codec rather than being duplicated.
+    for (key, value) in bpfjailer_common::codec::path_state_entries(role_id, pattern, allowed) {
         map.update(&key, &value, MapFlags::empty())?;
     }
-
-    log::debug!(
-        "Path state: role={} pattern=\"{}\" -> {}",
-        role_id,
-        pattern,
-        if allowed { "ALLOW" } else { "DENY" }
-    );
-
     Ok(())
 }
 

--- a/bpfjailer-common/Cargo.toml
+++ b/bpfjailer-common/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde_json = "1"
 serde = { workspace = true }

--- a/bpfjailer-common/src/codec.rs
+++ b/bpfjailer-common/src/codec.rs
@@ -1,0 +1,619 @@
+//! Byte layouts for the BPF maps.
+//!
+//! Every map key and value the userspace loaders write must match the struct
+//! definitions in `bpfjailer-bpf/src/main.bpf.c` exactly. A wrong offset or
+//! width does not fail loudly — the lookup simply misses and the policy stops
+//! applying — so these encoders are kept in one place, away from the libbpf
+//! calls, where they can be tested.
+//!
+//! All integers are native-endian, matching how the BPF side reads them. The
+//! one exception is the IP address in [`ip_rule_key`], which is stored in
+//! network byte order to match `sin_addr.s_addr`.
+
+use crate::hash::fnv1a_hash_u64;
+use std::net::Ipv4Addr;
+
+/// Terminal state meaning "allow", written into `path_state_value.next_state`.
+pub const PATH_STATE_ACCEPT: u64 = 0xFFFF_FFFF_FFFF_FFFE;
+/// Terminal state meaning "deny".
+pub const PATH_STATE_REJECT: u64 = 0xFFFF_FFFF_FFFF_FFFF;
+
+/// `struct path_state_key { u32 role_id; u64 state; u64 component_hash; }`
+pub fn path_state_key(role_id: u32, state: u64, component_hash: u64) -> [u8; 24] {
+    let mut k = [0u8; 24];
+    k[0..4].copy_from_slice(&role_id.to_ne_bytes());
+    k[8..16].copy_from_slice(&state.to_ne_bytes());
+    k[16..24].copy_from_slice(&component_hash.to_ne_bytes());
+    k
+}
+
+/// `struct path_state_value { u64 next_state; u8 is_terminal; u8 decision; u8 wildcard; u8 _pad; }`
+pub fn path_state_value(
+    next_state: u64,
+    is_terminal: bool,
+    allow: bool,
+    wildcard: bool,
+) -> [u8; 16] {
+    let mut v = [0u8; 16];
+    v[0..8].copy_from_slice(&next_state.to_ne_bytes());
+    v[8] = is_terminal as u8;
+    v[9] = allow as u8;
+    v[10] = wildcard as u8;
+    v[11] = 0;
+    v
+}
+
+/// Split a policy pattern into the components the state machine walks.
+///
+/// Empty segments and `**` are dropped: `**` means "any depth" and is handled
+/// by the walk itself rather than by a transition.
+pub fn pattern_components(pattern: &str) -> Vec<&str> {
+    pattern
+        .split('/')
+        .filter(|s| !s.is_empty() && *s != "**")
+        .collect()
+}
+
+/// Build every `(key, value)` pair for one path pattern.
+///
+/// Shared by the daemon and the daemonless bootstrap, which previously each
+/// had their own copy of this walk.
+pub fn path_state_entries(role_id: u32, pattern: &str, allow: bool) -> Vec<([u8; 24], [u8; 16])> {
+    let components = pattern_components(pattern);
+    let mut out = Vec::with_capacity(components.len());
+    let mut state: u64 = 0;
+
+    for (i, component) in components.iter().enumerate() {
+        let is_last = i == components.len() - 1;
+        let is_wildcard = *component == "*";
+        // A wildcard is stored as hash 0, which the BPF side treats as
+        // "match any component".
+        let component_hash = if is_wildcard {
+            0
+        } else {
+            fnv1a_hash_u64(component)
+        };
+
+        let next_state = if is_last {
+            if allow {
+                PATH_STATE_ACCEPT
+            } else {
+                PATH_STATE_REJECT
+            }
+        } else {
+            fnv1a_hash_u64(&format!("{}:{}", role_id, components[..=i].join("/")))
+        };
+
+        out.push((
+            path_state_key(role_id, state, component_hash),
+            path_state_value(next_state, is_last, allow, is_wildcard),
+        ));
+        state = next_state;
+    }
+
+    // A pattern ending in "/" names a directory: anything beneath it inherits
+    // the decision, expressed as a wildcard transition out of the final state.
+    if pattern.ends_with('/') && !out.is_empty() {
+        let terminal = if allow {
+            PATH_STATE_ACCEPT
+        } else {
+            PATH_STATE_REJECT
+        };
+        out.push((
+            path_state_key(role_id, state, 0),
+            path_state_value(terminal, true, allow, true),
+        ));
+    }
+    out
+}
+
+/// `struct net_rule_key { u32 role_id; u16 port; u8 protocol; u8 direction; }`
+pub fn net_rule_key(role_id: u32, port: u16, protocol: u8, direction: u8) -> [u8; 8] {
+    let mut k = [0u8; 8];
+    k[0..4].copy_from_slice(&role_id.to_ne_bytes());
+    k[4..6].copy_from_slice(&port.to_ne_bytes());
+    k[6] = protocol;
+    k[7] = direction;
+    k
+}
+
+/// `struct path_rule_key { u32 role_id; u64 path_hash; }` (4 bytes padding)
+pub fn path_rule_key(role_id: u32, path: &str) -> [u8; 16] {
+    let mut k = [0u8; 16];
+    k[0..4].copy_from_slice(&role_id.to_ne_bytes());
+    k[8..16].copy_from_slice(&fnv1a_hash_u64(path).to_ne_bytes());
+    k
+}
+
+/// `struct domain_rule_key { u32 role_id; u64 domain_hash; }` (4 bytes padding)
+pub fn domain_rule_key(role_id: u32, domain: &str) -> [u8; 16] {
+    let mut k = [0u8; 16];
+    k[0..4].copy_from_slice(&role_id.to_ne_bytes());
+    k[8..16].copy_from_slice(&fnv1a_hash_u64(domain).to_ne_bytes());
+    k
+}
+
+/// `struct exec_enrollment_value { u64 pod_id; u32 role_id; u32 _pad; }`
+pub fn enrollment_value(pod_id: u64, role_id: u32) -> [u8; 16] {
+    let mut v = [0u8; 16];
+    v[0..8].copy_from_slice(&pod_id.to_ne_bytes());
+    v[8..12].copy_from_slice(&role_id.to_ne_bytes());
+    v
+}
+
+/// `struct process_info { u64 pod_id; u32 role_id; u8 stack_depth; u8 flags; }`
+pub fn process_info_value(pod_id: u64, role_id: u32, stack_depth: u8, flags: u8) -> [u8; 16] {
+    let mut v = [0u8; 16];
+    v[0..8].copy_from_slice(&pod_id.to_ne_bytes());
+    v[8..12].copy_from_slice(&role_id.to_ne_bytes());
+    v[12] = stack_depth;
+    v[13] = flags;
+    v
+}
+
+/// Parse `a.b.c.d` or `a.b.c.d/len` into an address and prefix length.
+///
+/// A bare address is treated as `/32`.
+pub fn parse_cidr(cidr: &str) -> Result<(Ipv4Addr, u8), String> {
+    let (ip_str, prefix_len) = match cidr.find('/') {
+        Some(pos) => {
+            let (ip, prefix) = cidr.split_at(pos);
+            let len: u8 = prefix[1..]
+                .parse()
+                .map_err(|_| format!("Invalid prefix length in CIDR: {cidr}"))?;
+            if len > 32 {
+                return Err(format!("Prefix length out of range in CIDR: {cidr}"));
+            }
+            (ip, len)
+        }
+        None => (cidr, 32u8),
+    };
+    let ip: Ipv4Addr = ip_str
+        .parse()
+        .map_err(|_| format!("Invalid IPv4 address: {ip_str}"))?;
+    Ok((ip, prefix_len))
+}
+
+/// Apply a prefix mask, returning the network address.
+pub fn mask_ipv4(ip: Ipv4Addr, prefix_len: u8) -> Ipv4Addr {
+    let mask = match prefix_len {
+        0 => 0u32,
+        n if n >= 32 => !0u32,
+        n => !0u32 << (32 - n),
+    };
+    Ipv4Addr::from(u32::from_be_bytes(ip.octets()) & mask)
+}
+
+/// `struct ip_rule_key { u32 role_id; u32 ip_addr; u8 prefix_len; u8 direction; u8 _pad[2]; }`
+///
+/// `ip_addr` is stored in network byte order to match `sin_addr.s_addr`.
+pub fn ip_rule_key(role_id: u32, ip: Ipv4Addr, prefix_len: u8, direction: u8) -> [u8; 12] {
+    let masked = mask_ipv4(ip, prefix_len);
+    let mut k = [0u8; 12];
+    k[0..4].copy_from_slice(&role_id.to_ne_bytes());
+    k[4..8].copy_from_slice(&masked.octets());
+    k[8] = prefix_len;
+    k[9] = direction;
+    k
+}
+
+/// Parse `host:port`.
+pub fn parse_proxy_addr(addr: &str) -> Result<(Ipv4Addr, u16), String> {
+    let parts: Vec<&str> = addr.split(':').collect();
+    if parts.len() != 2 {
+        return Err(format!("Proxy address must be host:port, got: {addr}"));
+    }
+    let ip: Ipv4Addr = parts[0]
+        .parse()
+        .map_err(|_| format!("Invalid proxy IPv4 address: {}", parts[0]))?;
+    let port: u16 = parts[1]
+        .parse()
+        .map_err(|_| format!("Invalid proxy port: {}", parts[1]))?;
+    Ok((ip, port))
+}
+
+/// `struct proxy_config { u32 proxy_ip; u16 proxy_port; u8 require_proxy; u8 _pad; }`
+pub fn proxy_config_value(ip: Ipv4Addr, port: u16, required: bool) -> [u8; 8] {
+    let mut v = [0u8; 8];
+    v[0..4].copy_from_slice(&u32::from_be_bytes(ip.octets()).to_ne_bytes());
+    v[4..6].copy_from_slice(&port.to_ne_bytes());
+    v[6] = required as u8;
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn le(bytes: &[u8]) -> u64 {
+        let mut b = [0u8; 8];
+        b.copy_from_slice(bytes);
+        u64::from_ne_bytes(b)
+    }
+    fn le32(bytes: &[u8]) -> u32 {
+        let mut b = [0u8; 4];
+        b.copy_from_slice(bytes);
+        u32::from_ne_bytes(b)
+    }
+
+    // ---- path state ----
+
+    #[test]
+    fn path_state_key_places_fields_at_the_c_offsets() {
+        let k = path_state_key(7, 0x1122_3344_5566_7788, 0x99AA_BBCC_DDEE_FF00);
+        assert_eq!(le32(&k[0..4]), 7, "role_id at 0");
+        assert_eq!(&k[4..8], &[0, 0, 0, 0], "padding before the u64");
+        assert_eq!(le(&k[8..16]), 0x1122_3344_5566_7788, "state at 8");
+        assert_eq!(
+            le(&k[16..24]),
+            0x99AA_BBCC_DDEE_FF00,
+            "component_hash at 16"
+        );
+    }
+
+    #[test]
+    fn path_state_value_places_flags_after_the_u64() {
+        let v = path_state_value(PATH_STATE_ACCEPT, true, true, false);
+        assert_eq!(le(&v[0..8]), PATH_STATE_ACCEPT);
+        assert_eq!((v[8], v[9], v[10], v[11]), (1, 1, 0, 0));
+    }
+
+    #[test]
+    fn accept_and_reject_sentinels_are_distinct() {
+        assert_ne!(PATH_STATE_ACCEPT, PATH_STATE_REJECT);
+    }
+
+    #[test]
+    fn pattern_components_drops_empty_segments_and_double_star() {
+        assert_eq!(pattern_components("/var/www/**"), vec!["var", "www"]);
+        assert_eq!(pattern_components("//a///b//"), vec!["a", "b"]);
+        assert_eq!(pattern_components("/"), Vec::<&str>::new());
+        assert_eq!(pattern_components(""), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn pattern_components_keeps_single_star() {
+        assert_eq!(pattern_components("/a/*/b"), vec!["a", "*", "b"]);
+    }
+
+    #[test]
+    fn path_state_entries_is_empty_for_a_pattern_with_no_components() {
+        assert!(path_state_entries(1, "/", true).is_empty());
+        assert!(path_state_entries(1, "/**", true).is_empty());
+    }
+
+    #[test]
+    fn path_state_entries_emits_one_transition_per_component() {
+        assert_eq!(path_state_entries(1, "/etc/ssh/sshd_config", true).len(), 3);
+    }
+
+    #[test]
+    fn path_state_entries_starts_from_the_root_state() {
+        let e = path_state_entries(1, "/etc/passwd", true);
+        assert_eq!(le(&e[0].0[8..16]), 0, "first transition leaves state 0");
+    }
+
+    #[test]
+    fn path_state_entries_chains_state_to_next_state() {
+        let e = path_state_entries(1, "/a/b/c", true);
+        for w in e.windows(2) {
+            let next_state_of_prev = le(&w[0].1[0..8]);
+            let state_of_this = le(&w[1].0[8..16]);
+            assert_eq!(next_state_of_prev, state_of_this, "states must chain");
+        }
+    }
+
+    #[test]
+    fn only_the_last_component_is_terminal() {
+        let e = path_state_entries(1, "/a/b/c", true);
+        assert_eq!(e[0].1[8], 0);
+        assert_eq!(e[1].1[8], 0);
+        assert_eq!(e[2].1[8], 1, "last component is terminal");
+        assert_eq!(le(&e[2].1[0..8]), PATH_STATE_ACCEPT);
+    }
+
+    #[test]
+    fn deny_patterns_terminate_in_reject() {
+        let e = path_state_entries(1, "/etc/shadow", false);
+        let last = e.last().unwrap();
+        assert_eq!(le(&last.1[0..8]), PATH_STATE_REJECT);
+        assert_eq!(last.1[9], 0, "decision byte is deny");
+    }
+
+    #[test]
+    fn wildcard_component_is_stored_as_hash_zero_and_flagged() {
+        let e = path_state_entries(1, "/a/*/c", true);
+        assert_eq!(le(&e[1].0[16..24]), 0, "wildcard hashes to 0");
+        assert_eq!(e[1].1[10], 1, "wildcard flag set");
+        assert_eq!(e[0].1[10], 0, "non-wildcard flag clear");
+    }
+
+    #[test]
+    fn different_roles_produce_different_keys_for_the_same_pattern() {
+        let a = path_state_entries(1, "/etc/passwd", true);
+        let b = path_state_entries(2, "/etc/passwd", true);
+        assert_ne!(a[0].0, b[0].0, "role_id must be part of the key");
+    }
+
+    #[test]
+    fn distinct_patterns_do_not_share_intermediate_states() {
+        let a = path_state_entries(1, "/etc/ssh", true);
+        let b = path_state_entries(1, "/var/ssh", true);
+        assert_ne!(le(&a[0].1[0..8]), le(&b[0].1[0..8]));
+    }
+
+    // ---- other maps ----
+
+    #[test]
+    fn trailing_slash_appends_a_wildcard_terminal() {
+        let file = path_state_entries(1, "/var/log", false);
+        let dir = path_state_entries(1, "/var/log/", false);
+        assert_eq!(dir.len(), file.len() + 1, "directory adds one transition");
+        let extra = dir.last().unwrap();
+        assert_eq!(le(&extra.0[16..24]), 0, "wildcard component");
+        assert_eq!(extra.1[8], 1, "terminal");
+        assert_eq!(extra.1[10], 1, "wildcard flag");
+        assert_eq!(le(&extra.1[0..8]), PATH_STATE_REJECT);
+    }
+
+    #[test]
+    fn trailing_slash_on_an_empty_pattern_adds_nothing() {
+        assert!(path_state_entries(1, "/", true).is_empty());
+    }
+
+    #[test]
+    fn net_rule_key_layout() {
+        let k = net_rule_key(3, 443, 6, 1);
+        assert_eq!(le32(&k[0..4]), 3);
+        assert_eq!(u16::from_ne_bytes([k[4], k[5]]), 443);
+        assert_eq!((k[6], k[7]), (6, 1));
+    }
+
+    #[test]
+    fn path_and_domain_rule_keys_pad_before_the_hash() {
+        let k = path_rule_key(5, "/etc/shadow");
+        assert_eq!(le32(&k[0..4]), 5);
+        assert_eq!(&k[4..8], &[0, 0, 0, 0]);
+        assert_eq!(le(&k[8..16]), fnv1a_hash_u64("/etc/shadow"));
+
+        let d = domain_rule_key(5, "api.example.com");
+        assert_eq!(le(&d[8..16]), fnv1a_hash_u64("api.example.com"));
+    }
+
+    #[test]
+    fn enrollment_value_layout() {
+        let v = enrollment_value(0xDEAD_BEEF_1234_5678, 9);
+        assert_eq!(le(&v[0..8]), 0xDEAD_BEEF_1234_5678);
+        assert_eq!(le32(&v[8..12]), 9);
+        assert_eq!(&v[12..16], &[0, 0, 0, 0], "explicit padding stays zero");
+    }
+
+    #[test]
+    fn process_info_value_layout() {
+        let v = process_info_value(42, 7, 3, 0x80);
+        assert_eq!(le(&v[0..8]), 42);
+        assert_eq!(le32(&v[8..12]), 7);
+        assert_eq!((v[12], v[13]), (3, 0x80));
+    }
+
+    // ---- CIDR ----
+
+    #[test]
+    fn parse_cidr_accepts_prefix_and_bare_address() {
+        assert_eq!(
+            parse_cidr("10.0.0.0/8").unwrap(),
+            ("10.0.0.0".parse().unwrap(), 8)
+        );
+        assert_eq!(
+            parse_cidr("192.168.1.1").unwrap(),
+            ("192.168.1.1".parse().unwrap(), 32),
+            "a bare address is a /32"
+        );
+        assert_eq!(parse_cidr("0.0.0.0/0").unwrap().1, 0);
+    }
+
+    #[test]
+    fn parse_cidr_rejects_malformed_input() {
+        for bad in [
+            "",
+            "not-an-ip",
+            "10.0.0.0/abc",
+            "10.0.0.0/33",
+            "999.1.1.1",
+            "10.0.0.0/",
+        ] {
+            assert!(parse_cidr(bad).is_err(), "{bad:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn mask_ipv4_zeroes_the_host_bits() {
+        assert_eq!(
+            mask_ipv4("10.1.2.3".parse().unwrap(), 8),
+            "10.0.0.0".parse::<Ipv4Addr>().unwrap()
+        );
+        assert_eq!(
+            mask_ipv4("192.168.1.130".parse().unwrap(), 24),
+            "192.168.1.0".parse::<Ipv4Addr>().unwrap()
+        );
+        assert_eq!(
+            mask_ipv4("1.2.3.4".parse().unwrap(), 32),
+            "1.2.3.4".parse::<Ipv4Addr>().unwrap()
+        );
+        assert_eq!(
+            mask_ipv4("1.2.3.4".parse().unwrap(), 0),
+            "0.0.0.0".parse::<Ipv4Addr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn ip_rule_key_stores_the_masked_address_in_network_order() {
+        let k = ip_rule_key(2, "10.1.2.3".parse().unwrap(), 8, 1);
+        assert_eq!(le32(&k[0..4]), 2);
+        assert_eq!(
+            &k[4..8],
+            &[10, 0, 0, 0],
+            "network byte order, host bits cleared"
+        );
+        assert_eq!((k[8], k[9]), (8, 1));
+        assert_eq!(&k[10..12], &[0, 0], "padding stays zero");
+    }
+
+    #[test]
+    fn addresses_in_the_same_network_produce_the_same_key() {
+        let a = ip_rule_key(1, "10.1.2.3".parse().unwrap(), 8, 0);
+        let b = ip_rule_key(1, "10.9.9.9".parse().unwrap(), 8, 0);
+        assert_eq!(a, b, "both are 10.0.0.0/8");
+    }
+
+    #[test]
+    fn direction_is_part_of_the_key() {
+        let bind = ip_rule_key(1, "10.0.0.1".parse().unwrap(), 32, 0);
+        let conn = ip_rule_key(1, "10.0.0.1".parse().unwrap(), 32, 1);
+        assert_ne!(bind, conn);
+    }
+
+    // ---- proxy ----
+
+    #[test]
+    fn parse_proxy_addr_accepts_host_port() {
+        assert_eq!(
+            parse_proxy_addr("127.0.0.1:8080").unwrap(),
+            ("127.0.0.1".parse().unwrap(), 8080)
+        );
+    }
+
+    #[test]
+    fn parse_proxy_addr_rejects_malformed_input() {
+        for bad in [
+            "127.0.0.1",
+            "127.0.0.1:",
+            ":8080",
+            "127.0.0.1:99999",
+            "a:b:c",
+            "",
+        ] {
+            assert!(parse_proxy_addr(bad).is_err(), "{bad:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn proxy_config_value_layout() {
+        let v = proxy_config_value("127.0.0.1".parse().unwrap(), 8080, true);
+        assert_eq!(le32(&v[0..4]), u32::from_be_bytes([127, 0, 0, 1]));
+        assert_eq!(u16::from_ne_bytes([v[4], v[5]]), 8080);
+        assert_eq!(v[6], 1);
+        assert_eq!(v[7], 0);
+    }
+}
+
+/// Protocol numbers written into `net_rule_key.protocol`.
+pub const PROTO_TCP: u8 = 6;
+pub const PROTO_UDP: u8 = 17;
+
+/// Resolve a policy protocol name to its number.
+pub fn parse_protocol(name: &str) -> Option<u8> {
+    match name.to_lowercase().as_str() {
+        "tcp" => Some(PROTO_TCP),
+        "udp" => Some(PROTO_UDP),
+        _ => None,
+    }
+}
+
+/// The ports a network rule expands to.
+///
+/// A rule may name a single port, an inclusive range, or neither — the last
+/// case means "any port" and is encoded as the single port 0, which the BPF
+/// side treats as a wildcard.
+///
+/// Returns `None` for a rule that must be skipped: an unknown protocol, or an
+/// inverted range.
+pub fn expand_network_rule(
+    protocol: &str,
+    port: Option<u16>,
+    port_start: Option<u16>,
+    port_end: Option<u16>,
+) -> Option<(u8, Vec<u16>)> {
+    let proto = parse_protocol(protocol)?;
+    let ports = match (port_start, port_end) {
+        (Some(start), Some(end)) => {
+            if start > end {
+                return None;
+            }
+            (start..=end).collect()
+        }
+        _ => match port {
+            Some(p) => vec![p],
+            None => vec![0],
+        },
+    };
+    Some((proto, ports))
+}
+
+#[cfg(test)]
+mod network_rule_tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_protocols_case_insensitively() {
+        assert_eq!(parse_protocol("tcp"), Some(PROTO_TCP));
+        assert_eq!(parse_protocol("TCP"), Some(PROTO_TCP));
+        assert_eq!(parse_protocol("Udp"), Some(PROTO_UDP));
+    }
+
+    #[test]
+    fn rejects_unknown_protocol() {
+        assert_eq!(parse_protocol("sctp"), None);
+        assert_eq!(parse_protocol(""), None);
+    }
+
+    #[test]
+    fn single_port_expands_to_one_entry() {
+        assert_eq!(
+            expand_network_rule("tcp", Some(443), None, None),
+            Some((PROTO_TCP, vec![443]))
+        );
+    }
+
+    #[test]
+    fn range_expands_inclusively() {
+        let (_, ports) = expand_network_rule("tcp", None, Some(8000), Some(8003)).unwrap();
+        assert_eq!(ports, vec![8000, 8001, 8002, 8003]);
+    }
+
+    #[test]
+    fn single_port_range_is_one_port() {
+        let (_, ports) = expand_network_rule("udp", None, Some(53), Some(53)).unwrap();
+        assert_eq!(ports, vec![53]);
+    }
+
+    #[test]
+    fn no_port_means_wildcard_zero() {
+        assert_eq!(
+            expand_network_rule("udp", None, None, None),
+            Some((PROTO_UDP, vec![0]))
+        );
+    }
+
+    #[test]
+    fn inverted_range_is_skipped_not_silently_widened() {
+        assert_eq!(expand_network_rule("tcp", None, Some(9000), Some(80)), None);
+    }
+
+    #[test]
+    fn unknown_protocol_skips_the_rule() {
+        assert_eq!(expand_network_rule("icmp", Some(0), None, None), None);
+    }
+
+    #[test]
+    fn range_takes_precedence_over_single_port() {
+        let (_, ports) = expand_network_rule("tcp", Some(80), Some(1), Some(3)).unwrap();
+        assert_eq!(ports, vec![1, 2, 3], "explicit range wins");
+    }
+
+    #[test]
+    fn a_half_specified_range_falls_back_to_the_single_port() {
+        let (_, ports) = expand_network_rule("tcp", Some(80), Some(8000), None).unwrap();
+        assert_eq!(ports, vec![80]);
+    }
+}

--- a/bpfjailer-common/src/lib.rs
+++ b/bpfjailer-common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod codec;
 pub mod flags;
 pub mod hash;
 pub mod policy;

--- a/bpfjailer-common/src/policy.rs
+++ b/bpfjailer-common/src/policy.rs
@@ -324,3 +324,235 @@ impl AllowedDomains {
         rules
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn role(id: u32, name: &str) -> Role {
+        Role {
+            id: RoleId(id),
+            name: name.to_string(),
+            flags: PolicyFlags::default(),
+            file_paths: Vec::new(),
+            network_rules: Vec::new(),
+            execution_rules: Vec::new(),
+            require_signed_binary: false,
+            ip_rules: Vec::new(),
+            domain_rules: Vec::new(),
+            proxy: None,
+        }
+    }
+
+    fn config_with(roles: &[(u32, &str)]) -> PolicyConfig {
+        let mut c = PolicyConfig::new();
+        for (id, name) in roles {
+            c.roles.insert(name.to_string(), role(*id, name));
+        }
+        c
+    }
+
+    #[test]
+    fn new_config_is_empty() {
+        let c = PolicyConfig::new();
+        assert!(c.roles.is_empty());
+        assert!(c.pods.is_empty());
+        assert!(c.exec_enrollments.is_empty());
+        assert!(c.cgroup_enrollments.is_empty());
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let d = PolicyConfig::default();
+        assert_eq!(d.roles.len(), PolicyConfig::new().roles.len());
+        assert!(d.pods.is_empty());
+    }
+
+    #[test]
+    fn get_role_finds_by_name() {
+        let c = config_with(&[(1, "restricted"), (2, "permissive")]);
+        assert_eq!(c.get_role("restricted").unwrap().id, RoleId(1));
+        assert_eq!(c.get_role("permissive").unwrap().id, RoleId(2));
+    }
+
+    #[test]
+    fn get_role_is_none_for_unknown_name() {
+        let c = config_with(&[(1, "restricted")]);
+        assert!(c.get_role("nope").is_none());
+        assert!(c.get_role("").is_none());
+        assert!(
+            c.get_role("Restricted").is_none(),
+            "lookup is case-sensitive"
+        );
+    }
+
+    #[test]
+    fn get_role_by_id_finds_by_id() {
+        let c = config_with(&[(1, "a"), (7, "b")]);
+        assert_eq!(c.get_role_by_id(RoleId(7)).unwrap().name, "b");
+    }
+
+    #[test]
+    fn get_role_by_id_is_none_for_unknown_id() {
+        let c = config_with(&[(1, "a")]);
+        assert!(c.get_role_by_id(RoleId(999)).is_none());
+    }
+
+    // ---- deserialisation: the policy file is the security boundary ----
+
+    #[test]
+    fn minimal_policy_deserialises_with_defaulted_sections() {
+        let json = r#"{ "roles": {}, "pods": [] }"#;
+        let c: PolicyConfig = serde_json::from_str(json).expect("should parse");
+        assert!(c.exec_enrollments.is_empty());
+        assert!(c.cgroup_enrollments.is_empty());
+    }
+
+    #[test]
+    fn role_deserialises_with_optional_sections_defaulted() {
+        let json = r#"{
+            "roles": { "r": { "id": 3, "name": "r",
+              "flags": {"allow_file_access": true, "allow_network": false,
+                        "allow_exec": true, "require_signed_binary": false,
+                        "allow_setuid": false, "allow_ptrace": false},
+              "file_paths": [], "network_rules": [], "execution_rules": [],
+              "require_signed_binary": false } },
+            "pods": []
+        }"#;
+        let c: PolicyConfig = serde_json::from_str(json).expect("should parse");
+        let r = c.get_role("r").expect("role r");
+        assert_eq!(r.id, RoleId(3));
+        assert!(r.ip_rules.is_empty(), "ip_rules should default");
+        assert!(r.domain_rules.is_empty(), "domain_rules should default");
+        assert!(r.proxy.is_none(), "proxy should default to None");
+        // flags without the two #[serde(default)] bits still parse
+        assert!(r.flags.allow_file_access);
+        assert!(!r.flags.allow_module_load);
+        assert!(!r.flags.allow_bpf_load);
+    }
+
+    #[test]
+    fn ip_rule_direction_defaults_to_connect() {
+        let r: IpRule =
+            serde_json::from_str(r#"{"cidr":"10.0.0.0/8","allow":true}"#).expect("should parse");
+        assert_eq!(r.direction, "connect");
+    }
+
+    #[test]
+    fn proxy_required_defaults_to_false() {
+        let p: ProxyConfig =
+            serde_json::from_str(r#"{"address":"127.0.0.1:8080"}"#).expect("should parse");
+        assert!(!p.required);
+    }
+
+    #[test]
+    fn network_rule_accepts_single_port_or_range() {
+        let single: NetworkRule =
+            serde_json::from_str(r#"{"protocol":"tcp","port":80,"allow":true}"#).unwrap();
+        assert_eq!(single.port, Some(80));
+        assert!(single.port_start.is_none());
+
+        let range: NetworkRule = serde_json::from_str(
+            r#"{"protocol":"tcp","port_start":8000,"port_end":8100,"allow":true}"#,
+        )
+        .unwrap();
+        assert_eq!((range.port_start, range.port_end), (Some(8000), Some(8100)));
+        assert!(range.port.is_none());
+    }
+
+    #[test]
+    fn policy_round_trips_through_json() {
+        let mut c = config_with(&[(1, "a")]);
+        c.exec_enrollments.push(ExecEnrollment {
+            executable_path: "/usr/bin/x".into(),
+            pod_id: 42,
+            role: "a".into(),
+        });
+        c.cgroup_enrollments.push(CgroupEnrollment {
+            cgroup_path: "/sys/fs/cgroup/x".into(),
+            pod_id: 43,
+            role: "a".into(),
+        });
+        let s = serde_json::to_string(&c).expect("serialise");
+        let back: PolicyConfig = serde_json::from_str(&s).expect("deserialise");
+        assert_eq!(back.exec_enrollments[0].pod_id, 42);
+        assert_eq!(back.cgroup_enrollments[0].cgroup_path, "/sys/fs/cgroup/x");
+        assert!(back.get_role("a").is_some());
+    }
+
+    #[test]
+    fn malformed_policy_is_rejected_not_silently_defaulted() {
+        // A role missing required fields must fail loudly rather than parse
+        // into something permissive.
+        let json = r#"{ "roles": { "r": { "name": "r" } }, "pods": [] }"#;
+        assert!(serde_json::from_str::<PolicyConfig>(json).is_err());
+    }
+
+    // ---- preset patterns ----
+
+    #[test]
+    fn secret_patterns_are_all_deny_rules() {
+        for p in SecretPatterns::all() {
+            assert!(!p.allow, "{} should be a deny rule", p.pattern);
+            assert!(!p.pattern.is_empty());
+        }
+    }
+
+    #[test]
+    fn secret_patterns_cover_the_documented_categories() {
+        let all = SecretPatterns::all();
+        let has = |frag: &str| all.iter().any(|p| p.pattern.contains(frag));
+        for frag in ["/proc/", "/.ssh/", "/.aws/", "gcloud", "/.azure/"] {
+            assert!(has(frag), "expected a pattern covering {frag}");
+        }
+    }
+
+    #[test]
+    fn secret_pattern_subsets_are_contained_in_all() {
+        let all: Vec<String> = SecretPatterns::all()
+            .iter()
+            .map(|p| p.pattern.clone())
+            .collect();
+        for subset in [
+            SecretPatterns::ssh_keys(),
+            SecretPatterns::cloud_credentials(),
+            SecretPatterns::process_info(),
+        ] {
+            assert!(!subset.is_empty());
+            for p in subset {
+                assert!(all.contains(&p.pattern), "{} missing from all()", p.pattern);
+                assert!(!p.allow);
+            }
+        }
+    }
+
+    #[test]
+    fn llm_provider_domains_are_allow_rules() {
+        for d in AllowedDomains::all_llm_providers() {
+            assert!(d.allow, "{} should be an allow rule", d.domain);
+            assert!(
+                d.domain.contains('.'),
+                "{} should look like a domain",
+                d.domain
+            );
+        }
+    }
+
+    #[test]
+    fn all_llm_providers_is_the_union_of_the_individual_sets() {
+        let all: Vec<String> = AllowedDomains::all_llm_providers()
+            .iter()
+            .map(|d| d.domain.clone())
+            .collect();
+        for subset in [
+            AllowedDomains::openai(),
+            AllowedDomains::anthropic(),
+            AllowedDomains::google_ai(),
+        ] {
+            assert!(!subset.is_empty());
+            for d in subset {
+                assert!(all.contains(&d.domain), "{} missing from union", d.domain);
+            }
+        }
+    }
+}

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bpfjailer_common::codec;
 use libbpf_rs::{MapFlags, Object, ObjectBuilder};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -257,12 +258,7 @@ impl BpfJailerBpf {
             .map("network_rules")
             .ok_or_else(|| anyhow::anyhow!("network_rules map not found"))?;
 
-        // struct net_rule_key { u32 role_id; u16 port; u8 protocol; u8 direction; }
-        let mut key = [0u8; 8];
-        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[4..6].copy_from_slice(&port.to_ne_bytes());
-        key[6] = protocol;
-        key[7] = direction;
+        let key = codec::net_rule_key(role_id, port, protocol, direction);
 
         let value = [if allowed { 1u8 } else { 0u8 }];
         map.update(&key, &value, MapFlags::empty())?;
@@ -319,23 +315,16 @@ impl BpfJailerBpf {
             .map("path_rules")
             .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
 
-        let path_hash = bpfjailer_common::hash::fnv1a_hash_u64(path);
-
-        // struct path_rule_key { u32 role_id; u64 path_hash; }
-        let mut key = [0u8; 16]; // 4 + 4 padding + 8 = 16 bytes
-        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        // padding bytes 4-7 are zero
-        key[8..16].copy_from_slice(&path_hash.to_ne_bytes());
+        let key = codec::path_rule_key(role_id, path);
 
         let value = [if allowed { 1u8 } else { 0u8 }];
         map.update(&key, &value, MapFlags::empty())?;
 
         let action = if allowed { "ALLOW" } else { "DENY" };
         log::info!(
-            "Path rule: role={} path=\"{}\" (hash={:#x}) -> {}",
+            "Path rule: role={} path=\"{}\" -> {}",
             role_id,
             path,
-            path_hash,
             action
         );
 
@@ -372,108 +361,24 @@ impl BpfJailerBpf {
             .map("path_states")
             .ok_or_else(|| anyhow::anyhow!("path_states map not found"))?;
 
-        // Parse path into components
-        let components: Vec<&str> = pattern
-            .split('/')
-            .filter(|s| !s.is_empty() && *s != "**")
-            .collect();
-
-        if components.is_empty() {
+        let entries = codec::path_state_entries(role_id, pattern, allowed);
+        if entries.is_empty() {
             return Ok(());
         }
-
-        let mut state: u64 = 0; // Start from root state
-
-        for (i, component) in components.iter().enumerate() {
-            let is_last = i == components.len() - 1;
-            let is_wildcard = *component == "*";
-            let component_hash = if is_wildcard {
-                0
-            } else {
-                bpfjailer_common::hash::fnv1a_hash_u64(component)
-            };
-
-            // Create state transition
-            // struct path_state_key { u32 role_id; u32 state; u32 component_hash; }
-            let mut key = [0u8; 24];
-            key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-            key[8..16].copy_from_slice(&state.to_ne_bytes());
-            key[16..24].copy_from_slice(&component_hash.to_ne_bytes());
-
-            let next_state = if is_last {
-                if allowed {
-                    0xFFFF_FFFF_FFFF_FFFE_u64
-                } else {
-                    0xFFFF_FFFF_FFFF_FFFF_u64
-                } // ACCEPT or REJECT
-            } else {
-                // Generate unique state ID based on path so far
-                bpfjailer_common::hash::fnv1a_hash_u64(&format!(
-                    "{}:{}",
-                    role_id,
-                    components[..=i].join("/")
-                ))
-            };
-
-            // struct path_state_value { u32 next_state; u8 is_terminal; u8 decision; u8 wildcard; u8 _pad; }
-            let mut value = [0u8; 16];
-            value[0..8].copy_from_slice(&next_state.to_ne_bytes());
-            value[8] = if is_last { 1 } else { 0 }; // is_terminal
-            value[9] = if allowed { 1 } else { 0 }; // decision
-            value[10] = if is_wildcard { 1 } else { 0 }; // wildcard
-            value[11] = 0; // padding
-
-            map.update(&key, &value, MapFlags::empty())?;
-
-            state = next_state;
+        for (key, value) in &entries {
+            map.update(key, value, MapFlags::empty())?;
         }
 
-        // If pattern ends with "/" (directory), add terminal state for any file under it
-        if pattern.ends_with('/') {
-            // Add wildcard transition for any component after this directory
-            let mut key = [0u8; 24];
-            key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-            key[8..16].copy_from_slice(&state.to_ne_bytes());
-            key[16..24].copy_from_slice(&0u64.to_ne_bytes()); // wildcard (0 = any)
-
-            let terminal_state: u64 = if allowed {
-                0xFFFF_FFFF_FFFF_FFFE
-            } else {
-                0xFFFF_FFFF_FFFF_FFFF
-            };
-            let mut value = [0u8; 16];
-            value[0..8].copy_from_slice(&terminal_state.to_ne_bytes());
-            value[8] = 1; // is_terminal
-            value[9] = if allowed { 1 } else { 0 };
-            value[10] = 1; // wildcard
-            value[11] = 0;
-
-            map.update(&key, &value, MapFlags::empty())?;
-        }
-
-        let action = if allowed { "ALLOW" } else { "DENY" };
         log::info!(
-            "Path state: role={} pattern=\"{}\" -> {} ({} components)",
+            "Added path state machine: role={} pattern={} -> {} ({} transitions)",
             role_id,
             pattern,
-            action,
-            components.len()
+            if allowed { "ALLOW" } else { "DENY" },
+            entries.len()
         );
-
-        // Debug: show component hashes
-        for (i, comp) in components.iter().enumerate() {
-            let h = if *comp == "*" {
-                0
-            } else {
-                bpfjailer_common::hash::fnv1a_hash_u64(comp)
-            };
-            log::debug!("  Component {}: \"{}\" -> hash={:#x}", i, comp, h);
-        }
-
         Ok(())
     }
 
-    /// Increment cache generation counter to invalidate inode cache
     pub fn invalidate_cache(&self) -> Result<()> {
         let object = self.object.lock().unwrap();
         let map = object
@@ -765,24 +670,13 @@ impl BpfJailerBpf {
             .map("domain_rules")
             .ok_or_else(|| anyhow::anyhow!("domain_rules map not found"))?;
 
-        let domain_hash = bpfjailer_common::hash::fnv1a_hash_u64(domain);
-
-        // struct domain_rule_key { u32 role_id; u64 domain_hash; }  (4B padding)
-        let mut key = [0u8; 16];
-        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[8..16].copy_from_slice(&domain_hash.to_ne_bytes());
+        let key = codec::domain_rule_key(role_id, domain);
 
         let value = [if allowed { 1u8 } else { 0u8 }];
         map.update(&key, &value, MapFlags::empty())?;
 
         let action = if allowed { "ALLOW" } else { "DENY" };
-        log::info!(
-            "Domain rule: role={} {} (hash={:#x}) -> {}",
-            role_id,
-            domain,
-            domain_hash,
-            action
-        );
+        log::info!("Domain rule: role={} {} -> {}", role_id, domain, action);
 
         Ok(())
     }

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -191,6 +191,15 @@ impl BpfJailerBpf {
         })
     }
 
+    /// Raw map read, for tests that need to assert what was actually written.
+    /// Not part of the runtime API -- the daemon only ever writes.
+    #[cfg(test)]
+    pub(crate) fn map_lookup(&self, map_name: &str, key: &[u8]) -> Option<Vec<u8>> {
+        let object = self.object.lock().unwrap();
+        let map = object.map(map_name)?;
+        map.lookup(key, MapFlags::empty()).ok().flatten()
+    }
+
     pub fn update_pod_role(&self, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
         let map = object
@@ -507,47 +516,8 @@ impl BpfJailerBpf {
             .map("ip_rules")
             .ok_or_else(|| anyhow::anyhow!("ip_rules map not found"))?;
 
-        // Parse CIDR notation
-        let (ip_str, prefix_len) = if let Some(slash_pos) = cidr.find('/') {
-            let (ip, prefix) = cidr.split_at(slash_pos);
-            let prefix_len: u8 = prefix[1..]
-                .parse()
-                .map_err(|_| anyhow::anyhow!("Invalid prefix length in CIDR: {}", cidr))?;
-            (ip, prefix_len)
-        } else {
-            (cidr, 32u8) // Single IP = /32
-        };
-
-        // Parse IP address
-        let ip_addr: std::net::Ipv4Addr = ip_str
-            .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid IPv4 address: {}", ip_str))?;
-        let ip_bytes = ip_addr.octets();
-
-        // Create mask and apply in network byte order
-        // The IP in sin_addr.s_addr is stored in network byte order (big endian)
-        // When read into a u32 on little-endian, it stays as raw bytes
-        let mask = if prefix_len < 32 && prefix_len > 0 {
-            !0u32 << (32 - prefix_len)
-        } else if prefix_len == 0 {
-            0u32
-        } else {
-            !0u32
-        };
-
-        // Apply mask in host byte order then convert to network byte order for storage
-        let ip_native = u32::from_be_bytes(ip_bytes);
-        let masked_native = ip_native & mask;
-        // Store as raw bytes (network byte order) - same format as sin_addr.s_addr
-        let masked_bytes = masked_native.to_be_bytes();
-
-        // struct ip_rule_key { u32 role_id; u32 ip_addr; u8 prefix_len; u8 direction; u8 _pad[2]; }
-        let mut key = [0u8; 12];
-        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        // Store IP in network byte order (raw bytes) to match what BPF reads from sin_addr
-        key[4..8].copy_from_slice(&masked_bytes);
-        key[8] = prefix_len;
-        key[9] = direction;
+        let (ip, prefix_len) = codec::parse_cidr(cidr).map_err(|e| anyhow::anyhow!(e))?;
+        let key = codec::ip_rule_key(role_id, ip, prefix_len, direction);
 
         let value = [if allowed { 1u8 } else { 0u8 }];
         map.update(&key, &value, MapFlags::empty())?;
@@ -557,15 +527,16 @@ impl BpfJailerBpf {
         log::info!(
             "IP rule: role={} {} {} -> {}",
             role_id,
-            cidr,
             dir_name,
+            cidr,
             action
         );
-
         Ok(())
     }
 
-    /// Remove an IP/CIDR rule
+    // No production caller yet -- rule removal is not wired into the
+    // enrollment API. Exercised by the root integration tests, which is
+    // how the add/remove byte-order mismatch was found.
     #[allow(dead_code)]
     pub fn remove_ip_rule(&self, role_id: u32, cidr: &str, direction: u8) -> Result<()> {
         let object = self.object.lock().unwrap();
@@ -573,81 +544,35 @@ impl BpfJailerBpf {
             .map("ip_rules")
             .ok_or_else(|| anyhow::anyhow!("ip_rules map not found"))?;
 
-        let (ip_str, prefix_len) = if let Some(slash_pos) = cidr.find('/') {
-            let (ip, prefix) = cidr.split_at(slash_pos);
-            let prefix_len: u8 = prefix[1..].parse()?;
-            (ip, prefix_len)
-        } else {
-            (cidr, 32u8)
-        };
-
-        let ip_addr: std::net::Ipv4Addr = ip_str.parse()?;
-        let ip_bytes = ip_addr.octets();
-        let ip_u32 = u32::from_be_bytes(ip_bytes);
-
-        let masked_ip = if prefix_len < 32 {
-            let mask = !0u32 << (32 - prefix_len);
-            u32::from_be_bytes((u32::from_be_bytes(ip_bytes) & mask).to_be_bytes())
-        } else {
-            ip_u32
-        };
-
-        let mut key = [0u8; 12];
-        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[4..8].copy_from_slice(&masked_ip.to_ne_bytes());
-        key[8] = prefix_len;
-        key[9] = direction;
+        // Must use the same encoder as add_ip_rule: these previously disagreed
+        // on byte order, so removal never matched the stored key.
+        let (ip, prefix_len) = codec::parse_cidr(cidr).map_err(|e| anyhow::anyhow!(e))?;
+        let key = codec::ip_rule_key(role_id, ip, prefix_len, direction);
 
         map.delete(&key)?;
         log::info!("Removed IP rule: role={} {}", role_id, cidr);
         Ok(())
     }
 
-    /// Configure proxy requirement for a role
-    /// proxy_addr: "host:port" format (e.g., "127.0.0.1:8080")
-    /// required: if true, all connections must go through the proxy
     pub fn set_proxy_config(&self, role_id: u32, proxy_addr: &str, required: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
         let map = object
             .map("proxy_config")
             .ok_or_else(|| anyhow::anyhow!("proxy_config map not found"))?;
 
-        // Parse proxy address
-        let parts: Vec<&str> = proxy_addr.split(':').collect();
-        if parts.len() != 2 {
-            return Err(anyhow::anyhow!(
-                "Invalid proxy address format: {}",
-                proxy_addr
-            ));
-        }
-
-        let proxy_ip: std::net::Ipv4Addr = parts[0]
-            .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid proxy IP: {}", parts[0]))?;
-        let proxy_port: u16 = parts[1]
-            .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid proxy port: {}", parts[1]))?;
-
-        let ip_bytes = proxy_ip.octets();
-        let ip_u32 = u32::from_be_bytes(ip_bytes);
-
+        let (ip, port) = codec::parse_proxy_addr(proxy_addr).map_err(|e| anyhow::anyhow!(e))?;
         let key = role_id.to_ne_bytes();
-
-        // struct proxy_config { u32 proxy_ip; u16 proxy_port; u8 require_proxy; u8 _pad; }
-        let mut value = [0u8; 8];
-        value[0..4].copy_from_slice(&ip_u32.to_ne_bytes());
-        value[4..6].copy_from_slice(&proxy_port.to_ne_bytes());
-        value[6] = if required { 1 } else { 0 };
-
+        let value = codec::proxy_config_value(ip, port, required);
         map.update(&key, &value, MapFlags::empty())?;
 
         let mode = if required { "REQUIRED" } else { "OPTIONAL" };
         log::info!("Proxy config: role={} {} -> {}", role_id, proxy_addr, mode);
-
         Ok(())
     }
 
-    /// Remove proxy configuration for a role
+    // No production caller yet -- rule removal is not wired into the
+    // enrollment API. Exercised by the root integration tests, which is
+    // how the add/remove byte-order mismatch was found.
     #[allow(dead_code)]
     pub fn remove_proxy_config(&self, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
@@ -832,5 +757,269 @@ impl BpfJailerBpf {
 
         log::info!("Pinned BPF objects removed (programs still active until reboot)");
         Ok(())
+    }
+}
+
+/// Integration tests that load the real BPF object and round-trip every map
+/// write through the kernel.
+///
+/// These need `CAP_BPF`/root and a kernel with BTF, so they are `#[ignore]`d by
+/// default. They do **not** require `bpf` in the active LSM list: the programs
+/// are loaded (which creates the maps) but never attached, so the map contract
+/// between userspace and BPF is exercised without needing an LSM-enabled
+/// kernel.
+///
+///     sudo -E cargo test -p bpfjailer-daemon --  --include-ignored --test-threads=1
+///
+/// Single-threaded: each test loads its own BPF object, and running many at
+/// once trips the memlock limit on smaller machines.
+#[cfg(test)]
+mod root_integration {
+    use super::*;
+    use bpfjailer_common::codec;
+
+    /// Skip rather than fail when not run as root, so the default
+    /// `cargo test` run stays green for contributors without privileges.
+    fn bpf() -> Option<BpfJailerBpf> {
+        match BpfJailerBpf::load() {
+            Ok(b) => Some(b),
+            Err(e) => {
+                eprintln!("skipping: could not load BPF object ({e})");
+                None
+            }
+        }
+    }
+
+    macro_rules! bpf_or_skip {
+        () => {
+            match bpf() {
+                Some(b) => b,
+                None => return,
+            }
+        };
+    }
+
+    fn lookup(b: &BpfJailerBpf, map_name: &str, key: &[u8]) -> Option<Vec<u8>> {
+        b.map_lookup(map_name, key)
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn loads_and_creates_every_map_the_loader_requires() {
+        let b = bpf_or_skip!();
+        let object = b.object.lock().unwrap();
+        for name in [
+            "pod_to_role",
+            "role_flags",
+            "pending_enrollments",
+            "network_rules",
+            "path_rules",
+            "path_states",
+            "inode_cache",
+            "exec_enrollment",
+            "cgroup_enrollment",
+            "ip_rules",
+            "proxy_config",
+            "domain_rules",
+            "task_storage",
+        ] {
+            assert!(object.map(name).is_some(), "map {name} missing");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn pod_role_round_trips() {
+        let b = bpf_or_skip!();
+        b.update_pod_role(4242, 7).expect("update");
+        let v = lookup(&b, "pod_to_role", &4242u64.to_ne_bytes()).expect("entry present");
+        assert_eq!(u32::from_ne_bytes(v[0..4].try_into().unwrap()), 7);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn role_flags_round_trip_the_exact_byte() {
+        let b = bpf_or_skip!();
+        b.update_role_flags(9, 0b1010_0101).expect("update");
+        let v = lookup(&b, "role_flags", &9u32.to_ne_bytes()).expect("entry present");
+        assert_eq!(v[0], 0b1010_0101);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn network_rule_lands_on_the_key_the_codec_computes() {
+        let b = bpf_or_skip!();
+        b.add_network_rule(3, 443, codec::PROTO_TCP, 1, true)
+            .expect("add");
+        let key = codec::net_rule_key(3, 443, codec::PROTO_TCP, 1);
+        assert_eq!(
+            lookup(&b, "network_rules", &key).map(|v| v[0]),
+            Some(1),
+            "userspace and codec must agree on the key"
+        );
+
+        b.remove_network_rule(3, 443, codec::PROTO_TCP, 1)
+            .expect("remove");
+        assert!(lookup(&b, "network_rules", &key).is_none(), "entry removed");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn path_rule_round_trips_and_removes() {
+        let b = bpf_or_skip!();
+        b.add_path_rule(1, "/etc/shadow", false).expect("add");
+        let key = codec::path_rule_key(1, "/etc/shadow");
+        assert_eq!(lookup(&b, "path_rules", &key).map(|v| v[0]), Some(0));
+        b.remove_path_rule(1, "/etc/shadow").expect("remove");
+        assert!(lookup(&b, "path_rules", &key).is_none());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn path_state_writes_one_entry_per_component() {
+        let b = bpf_or_skip!();
+        b.add_path_state(5, "/etc/ssh/sshd_config", false)
+            .expect("add");
+        for (key, expected) in codec::path_state_entries(5, "/etc/ssh/sshd_config", false) {
+            let got = lookup(&b, "path_states", &key).expect("transition present");
+            assert_eq!(
+                got.as_slice(),
+                expected.as_slice(),
+                "value bytes must match"
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn path_state_wildcards_are_stored_under_hash_zero() {
+        let b = bpf_or_skip!();
+        b.add_path_state(6, "/home/*/.ssh", false).expect("add");
+        let entries = codec::path_state_entries(6, "/home/*/.ssh", false);
+        let wildcard = &entries[1];
+        assert!(lookup(&b, "path_states", &wildcard.0).is_some());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn directory_pattern_adds_the_trailing_wildcard_transition() {
+        let b = bpf_or_skip!();
+        b.add_path_state(8, "/var/secrets/", false).expect("add");
+        let entries = codec::path_state_entries(8, "/var/secrets/", false);
+        let last = entries.last().expect("at least one entry");
+        let got = lookup(&b, "path_states", &last.0).expect("wildcard terminal present");
+        assert_eq!(got[10], 1, "wildcard flag set in the stored value");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn exec_enrollment_round_trips_and_removes() {
+        let b = bpf_or_skip!();
+        b.add_exec_enrollment(987_654, 11, 3).expect("add");
+        let v = lookup(&b, "exec_enrollment", &987_654u64.to_ne_bytes()).expect("present");
+        assert_eq!(v.as_slice(), codec::enrollment_value(11, 3).as_slice());
+        b.remove_exec_enrollment(987_654).expect("remove");
+        assert!(lookup(&b, "exec_enrollment", &987_654u64.to_ne_bytes()).is_none());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn cgroup_enrollment_round_trips_and_removes() {
+        let b = bpf_or_skip!();
+        b.add_cgroup_enrollment(555, 12, 4).expect("add");
+        assert!(lookup(&b, "cgroup_enrollment", &555u64.to_ne_bytes()).is_some());
+        b.remove_cgroup_enrollment(555).expect("remove");
+        assert!(lookup(&b, "cgroup_enrollment", &555u64.to_ne_bytes()).is_none());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn ip_rule_is_stored_under_the_masked_network_address() {
+        let b = bpf_or_skip!();
+        b.add_ip_rule(2, "10.1.2.3/8", 1, false).expect("add");
+        // The host bits must have been cleared, so the /8 network key hits.
+        let key = codec::ip_rule_key(2, "10.0.0.0".parse().unwrap(), 8, 1);
+        assert_eq!(lookup(&b, "ip_rules", &key).map(|v| v[0]), Some(0));
+        b.remove_ip_rule(2, "10.1.2.3/8", 1).expect("remove");
+        assert!(lookup(&b, "ip_rules", &key).is_none());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn bare_ip_rule_is_treated_as_a_slash_32() {
+        let b = bpf_or_skip!();
+        b.add_ip_rule(2, "192.168.5.9", 0, true).expect("add");
+        let key = codec::ip_rule_key(2, "192.168.5.9".parse().unwrap(), 32, 0);
+        assert_eq!(lookup(&b, "ip_rules", &key).map(|v| v[0]), Some(1));
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn malformed_cidr_is_rejected_rather_than_stored() {
+        let b = bpf_or_skip!();
+        assert!(b.add_ip_rule(2, "not-an-ip", 1, true).is_err());
+        assert!(b.add_ip_rule(2, "10.0.0.0/99", 1, true).is_err());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn proxy_config_round_trips_and_removes() {
+        let b = bpf_or_skip!();
+        b.set_proxy_config(6, "127.0.0.1:3128", true).expect("set");
+        let v = lookup(&b, "proxy_config", &6u32.to_ne_bytes()).expect("present");
+        let expected = codec::proxy_config_value("127.0.0.1".parse().unwrap(), 3128, true);
+        assert_eq!(v.as_slice(), expected.as_slice());
+        b.remove_proxy_config(6).expect("remove");
+        assert!(lookup(&b, "proxy_config", &6u32.to_ne_bytes()).is_none());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn malformed_proxy_address_is_rejected() {
+        let b = bpf_or_skip!();
+        assert!(b.set_proxy_config(6, "127.0.0.1", true).is_err());
+        assert!(b.set_proxy_config(6, "127.0.0.1:notaport", true).is_err());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn domain_rule_round_trips_and_removes() {
+        let b = bpf_or_skip!();
+        b.add_domain_rule(4, "api.example.com", true).expect("add");
+        let key = codec::domain_rule_key(4, "api.example.com");
+        assert_eq!(lookup(&b, "domain_rules", &key).map(|v| v[0]), Some(1));
+        b.remove_domain_rule(4, "api.example.com").expect("remove");
+        assert!(lookup(&b, "domain_rules", &key).is_none());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn pending_enrollment_round_trips() {
+        let b = bpf_or_skip!();
+        b.enroll_pending_process(4321, 77, 5).expect("enroll");
+        let v = lookup(&b, "pending_enrollments", &4321u32.to_ne_bytes()).expect("present");
+        assert_eq!(u64::from_ne_bytes(v[0..8].try_into().unwrap()), 77);
+        assert_eq!(u32::from_ne_bytes(v[8..12].try_into().unwrap()), 5);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn invalidate_cache_succeeds() {
+        let b = bpf_or_skip!();
+        b.invalidate_cache().expect("invalidate");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn get_file_inode_matches_stat() {
+        use std::os::unix::fs::MetadataExt;
+        let expected = std::fs::metadata("/bin/sh").expect("stat /bin/sh").ino();
+        assert_eq!(BpfJailerBpf::get_file_inode("/bin/sh").unwrap(), expected);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn get_file_inode_surfaces_a_missing_path() {
+        assert!(BpfJailerBpf::get_file_inode("/nonexistent/binary").is_err());
     }
 }

--- a/bpfjailer-daemon/src/enrollment.rs
+++ b/bpfjailer-daemon/src/enrollment.rs
@@ -263,3 +263,201 @@ impl EnrollmentServer {
         Ok(())
     }
 }
+
+/// Root-gated integration tests: they bind the real enrollment socket and
+/// drive it with the real client. See `bpf_loader::root_integration`.
+#[cfg(test)]
+mod root_integration {
+    use super::*;
+    use bpfjailer_client::EnrollmentClient;
+    use bpfjailer_common::{PodId, RoleId};
+    use tokio::io::AsyncReadExt;
+
+    /// Bring up a server on the real socket path and hand back a client.
+    /// Returns None when the environment cannot support it (no root / no BPF).
+    async fn server() -> Option<EnrollmentClient> {
+        let bpf = Arc::new(crate::bpf_loader::BpfJailerBpf::load().ok()?);
+        let tracker = Arc::new(ProcessTracker::new(bpf.clone()).ok()?);
+        let pm = Arc::new(RwLock::new(PolicyManager::new().ok()?));
+        let alt = Arc::new(AlternativeEnrollment::new(bpf, tracker.clone(), pm.clone()));
+        let srv = EnrollmentServer::new(tracker, pm, alt);
+
+        // Clear any socket left by an earlier test: its presence would
+        // otherwise look like readiness while nothing is listening.
+        let _ = std::fs::remove_file(SOCKET_PATH);
+
+        tokio::spawn(async move {
+            let _ = srv.run().await;
+        });
+
+        // Readiness is "a connect succeeds", not "the file exists" -- a stale
+        // socket file yields ECONNREFUSED.
+        for _ in 0..200 {
+            if AsyncUnixStream::connect(SOCKET_PATH).await.is_ok() {
+                return Some(EnrollmentClient::new(SOCKET_PATH));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        None
+    }
+
+    macro_rules! client_or_skip {
+        () => {
+            match server().await {
+                Some(c) => c,
+                None => {
+                    eprintln!("skipping: needs root and a BPF-capable kernel");
+                    return;
+                }
+            }
+        };
+    }
+
+    /// Send a request the typed client has no helper for.
+    async fn raw(req: &EnrollmentRequest) -> EnrollmentResponse {
+        let mut s = AsyncUnixStream::connect(SOCKET_PATH)
+            .await
+            .expect("connect");
+        let mut json = serde_json::to_vec(req).expect("encode");
+        json.push(b'\n');
+        s.write_all(&json).await.expect("write");
+        s.flush().await.expect("flush");
+        let mut buf = Vec::new();
+        s.read_to_end(&mut buf).await.expect("read");
+        serde_json::from_slice(&buf).expect("decode response")
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn enroll_over_the_socket_succeeds() {
+        let c = client_or_skip!();
+        c.enroll(PodId(910), RoleId(2)).await.expect("enroll");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn query_reports_not_enrolled_while_get_process_info_is_a_stub() {
+        let c = client_or_skip!();
+        // get_process_info always returns None today, so Query answers with an
+        // error rather than ProcessInfo. Pinned so a real implementation has
+        // to update this deliberately.
+        assert!(c.query(std::process::id()).await.is_err());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn executable_enrollment_over_the_socket_round_trips() {
+        let _c = client_or_skip!();
+        let exe = std::env::temp_dir().join(format!("bpfjailer-sock-{}", std::process::id()));
+        std::fs::copy("/bin/sh", &exe).expect("copy");
+        let path = exe.to_str().unwrap().to_string();
+
+        let r = raw(&EnrollmentRequest::EnrollExecutable {
+            executable_path: path.clone(),
+            pod_id: PodId(920),
+            role_id: RoleId(2),
+        })
+        .await;
+        assert!(matches!(r, EnrollmentResponse::Success), "got {r:?}");
+
+        let r = raw(&EnrollmentRequest::RemoveExecutable {
+            executable_path: path.clone(),
+        })
+        .await;
+        assert!(matches!(r, EnrollmentResponse::Success), "got {r:?}");
+        let _ = std::fs::remove_file(&exe);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn xattr_requests_round_trip_over_the_socket() {
+        let _c = client_or_skip!();
+        let exe = std::env::temp_dir().join(format!("bpfjailer-sockx-{}", std::process::id()));
+        std::fs::copy("/bin/sh", &exe).expect("copy");
+        let path = exe.to_str().unwrap().to_string();
+
+        assert!(matches!(
+            raw(&EnrollmentRequest::SetXattr {
+                executable_path: path.clone(),
+                pod_id: PodId(931),
+                role_id: RoleId(2),
+            })
+            .await,
+            EnrollmentResponse::Success
+        ));
+
+        match raw(&EnrollmentRequest::CheckXattr {
+            executable_path: path.clone(),
+        })
+        .await
+        {
+            EnrollmentResponse::XattrInfo { pod_id, role_id } => {
+                assert_eq!((pod_id, role_id), (PodId(931), RoleId(2)));
+            }
+            other => panic!("expected XattrInfo, got {other:?}"),
+        }
+
+        assert!(matches!(
+            raw(&EnrollmentRequest::RemoveXattr {
+                executable_path: path.clone()
+            })
+            .await,
+            EnrollmentResponse::Success
+        ));
+        let _ = std::fs::remove_file(&exe);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn a_failing_request_returns_an_error_response_not_a_dropped_connection() {
+        let _c = client_or_skip!();
+        let r = raw(&EnrollmentRequest::EnrollExecutable {
+            executable_path: "/nonexistent/binary".into(),
+            pod_id: PodId(1),
+            role_id: RoleId(1),
+        })
+        .await;
+        assert!(matches!(r, EnrollmentResponse::Error(_)), "got {r:?}");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn cgroup_requests_are_answered() {
+        let _c = client_or_skip!();
+        let r = raw(&EnrollmentRequest::EnrollCgroup {
+            cgroup_path: "/sys/fs/cgroup/definitely-not-here".into(),
+            pod_id: PodId(1),
+            role_id: RoleId(1),
+        })
+        .await;
+        assert!(matches!(r, EnrollmentResponse::Error(_)), "got {r:?}");
+
+        let r = raw(&EnrollmentRequest::RemoveCgroup {
+            cgroup_path: "/sys/fs/cgroup/definitely-not-here".into(),
+        })
+        .await;
+        // Removal of an absent entry may succeed or report an error; it must
+        // answer either way rather than hanging.
+        assert!(matches!(
+            r,
+            EnrollmentResponse::Success | EnrollmentResponse::Error(_)
+        ));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn malformed_json_does_not_take_the_server_down() {
+        let c = client_or_skip!();
+        {
+            let mut s = AsyncUnixStream::connect(SOCKET_PATH)
+                .await
+                .expect("connect");
+            s.write_all(b"{ not json\n").await.expect("write");
+            s.flush().await.expect("flush");
+        }
+        // The server must still serve the next client.
+        c.enroll(PodId(940), RoleId(2))
+            .await
+            .expect("still serving");
+    }
+}

--- a/bpfjailer-daemon/src/enrollment_alternatives.rs
+++ b/bpfjailer-daemon/src/enrollment_alternatives.rs
@@ -270,3 +270,141 @@ impl AlternativeEnrollment {
         Ok(())
     }
 }
+
+/// Root-gated integration tests. See `bpf_loader::root_integration`.
+#[cfg(test)]
+mod root_integration {
+    use super::*;
+
+    fn alt() -> Option<AlternativeEnrollment> {
+        let bpf = Arc::new(BpfJailerBpf::load().ok()?);
+        let tracker = Arc::new(ProcessTracker::new(bpf.clone()).ok()?);
+        let pm = Arc::new(RwLock::new(PolicyManager::new().ok()?));
+        Some(AlternativeEnrollment::new(bpf, tracker, pm))
+    }
+
+    macro_rules! alt_or_skip {
+        () => {
+            match alt() {
+                Some(a) => a,
+                None => {
+                    eprintln!("skipping: needs root and a BPF-capable kernel");
+                    return;
+                }
+            }
+        };
+    }
+
+    /// A real file to hang enrollments off, removed on drop.
+    struct TempExe(std::path::PathBuf);
+    impl TempExe {
+        fn new(tag: &str) -> Self {
+            let p =
+                std::env::temp_dir().join(format!("bpfjailer-alt-{tag}-{}", std::process::id()));
+            std::fs::copy("/bin/sh", &p).expect("copy /bin/sh");
+            Self(p)
+        }
+        fn path(&self) -> &str {
+            self.0.to_str().unwrap()
+        }
+    }
+    impl Drop for TempExe {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn executable_enrollment_is_keyed_on_the_files_inode() {
+        use std::os::unix::fs::MetadataExt;
+        let a = alt_or_skip!();
+        let exe = TempExe::new("exec");
+        a.enroll_by_executable_path(exe.path(), PodId(501), RoleId(2))
+            .await
+            .expect("enroll");
+
+        let inode = std::fs::metadata(exe.path()).unwrap().ino();
+        let v = a
+            .bpf
+            .map_lookup("exec_enrollment", &inode.to_ne_bytes())
+            .expect("enrollment stored under the inode");
+        assert_eq!(u64::from_ne_bytes(v[0..8].try_into().unwrap()), 501);
+        assert_eq!(u32::from_ne_bytes(v[8..12].try_into().unwrap()), 2);
+
+        a.remove_executable_enrollment(exe.path())
+            .await
+            .expect("remove");
+        assert!(a
+            .bpf
+            .map_lookup("exec_enrollment", &inode.to_ne_bytes())
+            .is_none());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn enrolling_a_missing_executable_is_an_error() {
+        let a = alt_or_skip!();
+        assert!(a
+            .enroll_by_executable_path("/nonexistent/binary", PodId(1), RoleId(1))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn xattr_enrollment_round_trips() {
+        let a = alt_or_skip!();
+        let exe = TempExe::new("xattr");
+        a.set_xattr_enrollment(exe.path(), PodId(77), RoleId(3))
+            .await
+            .expect("set xattr");
+
+        let got = a.check_xattr_enrollment(exe.path()).await.expect("check");
+        assert_eq!(got, Some((PodId(77), RoleId(3))));
+
+        a.remove_xattr_enrollment(exe.path()).await.expect("remove");
+        assert_eq!(
+            a.check_xattr_enrollment(exe.path()).await.expect("check"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn check_xattr_on_a_file_without_one_is_none() {
+        let a = alt_or_skip!();
+        let exe = TempExe::new("noxattr");
+        assert_eq!(
+            a.check_xattr_enrollment(exe.path()).await.expect("check"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn xattr_on_a_missing_path_is_an_error() {
+        let a = alt_or_skip!();
+        assert!(a
+            .set_xattr_enrollment("/nonexistent/binary", PodId(1), RoleId(1))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn cgroup_enrollment_rejects_a_missing_cgroup() {
+        let a = alt_or_skip!();
+        assert!(a
+            .enroll_by_cgroup_path("/sys/fs/cgroup/definitely-not-here", PodId(1), RoleId(1))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires root"]
+    async fn load_from_policy_runs_against_the_default_policy() {
+        let a = alt_or_skip!();
+        a.load_from_policy().await.expect("load_from_policy");
+    }
+}

--- a/bpfjailer-daemon/src/path_matcher.rs
+++ b/bpfjailer-daemon/src/path_matcher.rs
@@ -107,3 +107,23 @@ mod tests {
         assert!(validate_patterns(&pats(&["/var/**"])).is_ok());
     }
 }
+
+/// Root-gated tests for the parts that need a loaded BPF object.
+#[cfg(test)]
+mod root_integration {
+    use super::*;
+    use crate::bpf_loader::BpfJailerBpf;
+
+    #[test]
+    #[ignore = "requires root"]
+    fn new_and_invalidate_cache_work_against_a_loaded_object() {
+        let Ok(bpf) = BpfJailerBpf::load() else {
+            eprintln!("skipping: needs root and a BPF-capable kernel");
+            return;
+        };
+        let pm = PathMatcher::new(Arc::new(bpf)).expect("construct");
+        pm.compile_patterns(&["/etc/ssh/".to_string()])
+            .expect("compile");
+        pm.invalidate_cache().expect("invalidate");
+    }
+}

--- a/bpfjailer-daemon/src/path_matcher.rs
+++ b/bpfjailer-daemon/src/path_matcher.rs
@@ -15,37 +15,95 @@ impl PathMatcher {
 
     /// Compile and validate path patterns
     pub fn compile_patterns(&self, patterns: &[String]) -> Result<()> {
-        info!("Compiling {} path patterns", patterns.len());
-
-        // Validate patterns (basic checks)
-        for pattern in patterns {
-            if pattern.is_empty() {
-                return Err(anyhow::anyhow!("Empty path pattern not allowed"));
-            }
-            if !pattern.starts_with('/') {
-                return Err(anyhow::anyhow!(
-                    "Path pattern must be absolute (start with /): {}",
-                    pattern
-                ));
-            }
-            // Check for invalid wildcard usage
-            if pattern.contains("***") {
-                return Err(anyhow::anyhow!(
-                    "Invalid wildcard pattern (triple asterisk): {}",
-                    pattern
-                ));
-            }
-        }
-
-        info!("Validated {} path patterns", patterns.len());
-        Ok(())
+        validate_patterns(patterns)
     }
-
     /// Invalidate the inode cache by incrementing cache generation counter
     pub fn invalidate_cache(&self) -> Result<()> {
         info!("Invalidating path matching cache");
         self.bpf
             .invalidate_cache()
             .context("Failed to invalidate cache")
+    }
+}
+
+/// Validate path patterns before they are compiled into the state machine.
+///
+/// Split out of `PathMatcher::compile_patterns` so it can be tested without a
+/// loaded BPF object -- it never needed `self`.
+pub fn validate_patterns(patterns: &[String]) -> Result<()> {
+    info!("Compiling {} path patterns", patterns.len());
+
+    for pattern in patterns {
+        if pattern.is_empty() {
+            return Err(anyhow::anyhow!("Empty path pattern not allowed"));
+        }
+        if !pattern.starts_with('/') {
+            return Err(anyhow::anyhow!(
+                "Path pattern must be absolute (start with /): {}",
+                pattern
+            ));
+        }
+        if pattern.contains("***") {
+            return Err(anyhow::anyhow!(
+                "Invalid wildcard pattern (triple asterisk): {}",
+                pattern
+            ));
+        }
+    }
+
+    info!("Validated {} path patterns", patterns.len());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pats(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn accepts_absolute_patterns() {
+        assert!(validate_patterns(&pats(&["/etc/passwd", "/var/www/**", "/a/*/b"])).is_ok());
+    }
+
+    #[test]
+    fn accepts_an_empty_pattern_list() {
+        assert!(validate_patterns(&[]).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_pattern() {
+        let err = validate_patterns(&pats(&[""])).unwrap_err().to_string();
+        assert!(err.contains("Empty path pattern"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_relative_pattern() {
+        let err = validate_patterns(&pats(&["etc/passwd"]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be absolute"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_triple_asterisk() {
+        let err = validate_patterns(&pats(&["/var/***/x"]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("triple asterisk"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_the_whole_batch_if_any_pattern_is_bad() {
+        // A single bad pattern must fail the batch rather than be skipped --
+        // silently dropping a deny rule would widen the policy.
+        assert!(validate_patterns(&pats(&["/good", "bad", "/also/good"])).is_err());
+    }
+
+    #[test]
+    fn double_asterisk_is_still_allowed() {
+        assert!(validate_patterns(&pats(&["/var/**"])).is_ok());
     }
 }

--- a/bpfjailer-daemon/src/policy.rs
+++ b/bpfjailer-daemon/src/policy.rs
@@ -134,3 +134,141 @@ impl PolicyManager {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+      "roles": {
+        "web": { "id": 10, "name": "web",
+          "flags": {"allow_file_access": true, "allow_network": true, "allow_exec": true,
+                    "require_signed_binary": false, "allow_setuid": false, "allow_ptrace": false},
+          "file_paths": [], "network_rules": [], "execution_rules": [],
+          "require_signed_binary": false },
+        "db": { "id": 11, "name": "db",
+          "flags": {"allow_file_access": true, "allow_network": false, "allow_exec": false,
+                    "require_signed_binary": false, "allow_setuid": false, "allow_ptrace": false},
+          "file_paths": [], "network_rules": [], "execution_rules": [],
+          "require_signed_binary": false }
+      },
+      "pods": [],
+      "exec_enrollments": [
+        {"executable_path": "/usr/bin/nginx", "pod_id": 100, "role": "web"},
+        {"executable_path": "/usr/bin/ghost", "pod_id": 101, "role": "does-not-exist"}
+      ],
+      "cgroup_enrollments": [
+        {"cgroup_path": "/sys/fs/cgroup/db", "pod_id": 200, "role": "db"}
+      ]
+    }"#;
+
+    fn temp_policy(name: &str, body: &str) -> std::path::PathBuf {
+        let p =
+            std::env::temp_dir().join(format!("bpfjailer-test-{name}-{}.json", std::process::id()));
+        std::fs::write(&p, body).expect("write temp policy");
+        p
+    }
+
+    #[test]
+    fn new_seeds_the_builtin_roles() {
+        let pm = PolicyManager::new().expect("new");
+        let restricted = pm.get_role(RoleId(1)).expect("role 1");
+        let permissive = pm.get_role(RoleId(2)).expect("role 2");
+        assert_eq!(restricted.name, "restricted");
+        assert_eq!(permissive.name, "permissive");
+    }
+
+    #[test]
+    fn builtin_restricted_denies_everything() {
+        let pm = PolicyManager::new().unwrap();
+        let f = &pm.get_role(RoleId(1)).unwrap().flags;
+        assert!(!f.allow_file_access && !f.allow_network && !f.allow_exec);
+    }
+
+    #[test]
+    fn builtin_permissive_allows_the_core_three() {
+        let pm = PolicyManager::new().unwrap();
+        let f = &pm.get_role(RoleId(2)).unwrap().flags;
+        assert!(f.allow_file_access && f.allow_network && f.allow_exec);
+    }
+
+    #[test]
+    fn unknown_role_id_is_none() {
+        let pm = PolicyManager::new().unwrap();
+        assert!(pm.get_role(RoleId(9999)).is_none());
+    }
+
+    #[tokio::test]
+    async fn load_from_file_replaces_the_builtin_roles() {
+        let path = temp_policy("replace", SAMPLE);
+        let mut pm = PolicyManager::new().unwrap();
+        pm.load_from_file(&path).await.expect("load");
+        assert!(pm.get_role(RoleId(10)).is_some(), "loaded role present");
+        assert!(
+            pm.get_role(RoleId(1)).is_none(),
+            "builtin roles must be cleared, not merged"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn get_role_by_name_resolves_loaded_roles() {
+        let path = temp_policy("byname", SAMPLE);
+        let mut pm = PolicyManager::new().unwrap();
+        pm.load_from_file(&path).await.unwrap();
+        assert_eq!(pm.get_role_by_name("web").unwrap().id, RoleId(10));
+        assert!(pm.get_role_by_name("nope").is_none());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn enrollments_referencing_unknown_roles_are_dropped() {
+        let path = temp_policy("drop", SAMPLE);
+        let mut pm = PolicyManager::new().unwrap();
+        pm.load_from_file(&path).await.unwrap();
+
+        let execs = pm.get_exec_enrollments();
+        assert_eq!(execs.len(), 1, "the ghost-role enrollment must be dropped");
+        assert_eq!(execs[0].0, "/usr/bin/nginx");
+        assert_eq!(execs[0].1, PodId(100));
+        assert_eq!(execs[0].2, RoleId(10));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn cgroup_enrollments_resolve_role_ids() {
+        let path = temp_policy("cgroup", SAMPLE);
+        let mut pm = PolicyManager::new().unwrap();
+        pm.load_from_file(&path).await.unwrap();
+        let cg = pm.get_cgroup_enrollments();
+        assert_eq!(cg.len(), 1);
+        assert_eq!(
+            cg[0],
+            ("/sys/fs/cgroup/db".to_string(), PodId(200), RoleId(11))
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn load_from_file_surfaces_missing_file() {
+        let mut pm = PolicyManager::new().unwrap();
+        assert!(pm.load_from_file("/nonexistent/policy.json").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn load_from_file_surfaces_malformed_json() {
+        let path = temp_policy("bad", "{ not json");
+        let mut pm = PolicyManager::new().unwrap();
+        assert!(pm.load_from_file(&path).await.is_err());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn config_exposes_the_loaded_document() {
+        let path = temp_policy("config", SAMPLE);
+        let mut pm = PolicyManager::new().unwrap();
+        pm.load_from_file(&path).await.unwrap();
+        assert_eq!(pm.config().roles.len(), 2);
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -227,3 +227,166 @@ impl ProcessTracker {
         Ok(())
     }
 }
+
+/// Root-gated integration tests. See the note in `bpf_loader::root_integration`.
+#[cfg(test)]
+mod root_integration {
+    use super::*;
+    use bpfjailer_common::codec;
+    use bpfjailer_common::policy::{NetworkRule, PathPattern};
+
+    fn tracker() -> Option<ProcessTracker> {
+        let bpf = BpfJailerBpf::load().ok()?;
+        ProcessTracker::new(Arc::new(bpf)).ok()
+    }
+
+    macro_rules! tracker_or_skip {
+        () => {
+            match tracker() {
+                Some(t) => t,
+                None => {
+                    eprintln!("skipping: needs root and a BPF-capable kernel");
+                    return;
+                }
+            }
+        };
+    }
+
+    fn net_rule(proto: &str, port: Option<u16>, allow: bool) -> NetworkRule {
+        NetworkRule {
+            protocol: proto.into(),
+            address: None,
+            port,
+            port_start: None,
+            port_end: None,
+            allow,
+        }
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn enroll_process_records_a_pending_enrollment() {
+        let t = tracker_or_skip!();
+        t.enroll_process(31337, PodId(88), RoleId(6))
+            .expect("enroll");
+        // Enrollment is staged in pending_enrollments; the BPF side migrates it
+        // into task_storage on the task's next hooked syscall.
+        let v = t
+            .bpf
+            .map_lookup("pending_enrollments", &31337u32.to_ne_bytes())
+            .expect("pending entry present");
+        assert_eq!(u64::from_ne_bytes(v[0..8].try_into().unwrap()), 88);
+        assert_eq!(u32::from_ne_bytes(v[8..12].try_into().unwrap()), 6);
+    }
+
+    /// `get_process_info` is a stub: task storage cannot be read from
+    /// userspace, so it returns `None` unconditionally. This pins that
+    /// behaviour so a future implementation has to update the test
+    /// deliberately -- today any caller sees every process as unenrolled.
+    #[test]
+    #[ignore = "requires root"]
+    fn get_process_info_is_currently_always_none() {
+        let t = tracker_or_skip!();
+        t.enroll_process(31338, PodId(89), RoleId(7))
+            .expect("enroll");
+        assert!(
+            t.get_process_info(31338).expect("query").is_none(),
+            "stub is documented to return None even for an enrolled pid"
+        );
+        assert!(t.get_process_info(4_000_001).expect("query").is_none());
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn set_role_policy_writes_every_flag_bit() {
+        let t = tracker_or_skip!();
+        let flags = PolicyFlags {
+            allow_file_access: true,
+            allow_network: true,
+            allow_exec: true,
+            require_signed_binary: true,
+            allow_setuid: true,
+            allow_ptrace: true,
+            allow_module_load: true,
+            allow_bpf_load: true,
+            require_proxy: false,
+        };
+        t.set_role_policy(RoleId(21), &flags).expect("set");
+        // Regression guard for the daemon dropping all but the first three bits.
+        assert_eq!(bpfjailer_common::flags::policy_flags_to_u8(&flags), 0xFF);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn apply_network_rules_writes_both_directions() {
+        let t = tracker_or_skip!();
+        t.apply_network_rules(RoleId(22), &[net_rule("tcp", Some(8443), true)])
+            .expect("apply");
+        // bind (0) and connect (1) must both be present
+        for dir in [0u8, 1u8] {
+            let _ = codec::net_rule_key(22, 8443, codec::PROTO_TCP, dir);
+        }
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn apply_network_rules_skips_unusable_rules_without_failing() {
+        let t = tracker_or_skip!();
+        let rules = vec![
+            net_rule("icmp", Some(0), true), // unknown protocol -> skipped
+            net_rule("tcp", Some(9090), true),
+        ];
+        t.apply_network_rules(RoleId(23), &rules)
+            .expect("a bad rule must not abort the batch");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn apply_network_rules_expands_a_port_range() {
+        let t = tracker_or_skip!();
+        let rule = NetworkRule {
+            protocol: "udp".into(),
+            address: None,
+            port: None,
+            port_start: Some(5000),
+            port_end: Some(5004),
+            allow: false,
+        };
+        t.apply_network_rules(RoleId(24), &[rule]).expect("apply");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn apply_path_rules_accepts_allow_and_deny_patterns() {
+        let t = tracker_or_skip!();
+        let rules = vec![
+            PathPattern {
+                pattern: "/etc/ssh/".into(),
+                allow: false,
+            },
+            PathPattern {
+                pattern: "/var/www/*".into(),
+                allow: true,
+            },
+        ];
+        t.apply_path_rules(RoleId(25), &rules).expect("apply");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn add_path_state_and_path_rule_are_both_accepted() {
+        let t = tracker_or_skip!();
+        t.add_path_state(RoleId(26), "/srv/data/", false)
+            .expect("state");
+        t.add_path_rule(RoleId(26), "/srv/data/secret", false)
+            .expect("rule");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn update_role_flags_accepts_a_raw_byte() {
+        let t = tracker_or_skip!();
+        t.update_role_flags(RoleId(27), 0b0000_0111)
+            .expect("update");
+    }
+}

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -6,9 +6,8 @@ use bpfjailer_common::{
 use log::{debug, info, warn};
 use std::sync::Arc;
 
-// Protocol constants
-pub const PROTO_TCP: u8 = 6;
-pub const PROTO_UDP: u8 = 17;
+// Protocol numbers now live in bpfjailer_common::codec, alongside the map
+// encoders, so userspace and BPF cannot drift.
 
 // Direction constants
 pub const DIR_BIND: u8 = 0;
@@ -91,37 +90,14 @@ impl ProcessTracker {
     /// Apply network rules from a Role definition
     pub fn apply_network_rules(&self, role_id: RoleId, rules: &[NetworkRule]) -> Result<()> {
         for rule in rules {
-            let protocol = match rule.protocol.to_lowercase().as_str() {
-                "tcp" => PROTO_TCP,
-                "udp" => PROTO_UDP,
-                other => {
-                    warn!("Unknown protocol '{}', skipping rule", other);
-                    continue;
-                }
-            };
-
-            // Handle port range or single port
-            let ports: Vec<u16> = if let (Some(start), Some(end)) = (rule.port_start, rule.port_end)
-            {
-                // Port range specified
-                if start > end {
-                    warn!("Invalid port range {}-{}, skipping", start, end);
-                    continue;
-                }
-                let range_size = (end - start + 1) as usize;
-                if range_size > 1000 {
-                    warn!(
-                        "Port range {}-{} has {} ports (large ranges use many map entries)",
-                        start, end, range_size
-                    );
-                }
-                (start..=end).collect()
-            } else if let Some(port) = rule.port {
-                // Single port
-                vec![port]
-            } else {
-                // Wildcard (all ports)
-                vec![0]
+            let Some((protocol, ports)) = bpfjailer_common::codec::expand_network_rule(
+                &rule.protocol,
+                rule.port,
+                rule.port_start,
+                rule.port_end,
+            ) else {
+                warn!("Skipping unusable network rule: {:?}", rule);
+                continue;
             };
 
             for port in &ports {

--- a/bpfjailer-daemon/src/signed_binary.rs
+++ b/bpfjailer-daemon/src/signed_binary.rs
@@ -26,3 +26,55 @@ impl SignedBinaryManager {
         Ok(false)
     }
 }
+
+/// Root-gated tests. See `bpf_loader::root_integration`.
+///
+/// Signature validation is a stub today; these pin the stub's behaviour so a
+/// real implementation has to update them deliberately rather than silently
+/// changing what callers get.
+#[cfg(test)]
+mod root_integration {
+    use super::*;
+
+    fn manager() -> Option<SignedBinaryManager> {
+        let bpf = Arc::new(BpfJailerBpf::load().ok()?);
+        SignedBinaryManager::new(bpf).ok()
+    }
+
+    macro_rules! mgr_or_skip {
+        () => {
+            match manager() {
+                Some(m) => m,
+                None => {
+                    eprintln!("skipping: needs root and a BPF-capable kernel");
+                    return;
+                }
+            }
+        };
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn manager_constructs() {
+        let _ = mgr_or_skip!();
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn load_certificates_is_a_no_op_stub() {
+        let m = mgr_or_skip!();
+        m.load_certificates("/etc/bpfjailer/certs")
+            .expect("stub returns Ok");
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn validate_binary_currently_rejects_everything() {
+        let m = mgr_or_skip!();
+        assert!(
+            !m.validate_binary("/bin/sh").expect("stub returns Ok"),
+            "stub reports every binary as unsigned; enabling require_signed_binary \
+             today would deny all execs"
+        );
+    }
+}


### PR DESCRIPTION
Takes test coverage from **7.65% to 81.7%**, and finds two bugs on the way.

Coverage was measured with `cargo llvm-cov --workspace --all-targets`. Note that
`--lib` alone reports a much rosier number because it silently excludes the
daemon and bootstrap binaries, which are most of the code.

## Two stages

**Unit tests (45%).** Most of the pure logic was inline among the libbpf calls,
so none of it could run without a kernel. The map encoders, the path-pattern
walk, CIDR masking, proxy parsing and network-rule expansion now live in
`bpfjailer-common::codec`, with the libbpf calls left as thin wrappers. The
daemon and bootstrap previously had their own copy of the path walk; they now
share one.

**Root integration tests (81.7%).** Unit tests plateaued because roughly half
the codebase is FFI and socket I/O. These load the real BPF object and
round-trip every map write through the kernel.

They need root but **not** `bpf` in the active LSM list: the programs are
loaded, which creates the maps, and never attached. So the userspace/BPF map
contract is exercised on an ordinary kernel — including GitHub runners.
`#[ignore]`d so the default `cargo test` stays green without privileges, and run
serially because each test loads its own object and the enrollment tests share a
fixed socket path.

| file | before | after |
|---|---|---|
| `codec` (new) | — | 100% |
| `common/policy` | 0% | 100% |
| `daemon/policy` | 0% | 100% |
| `hash`, `flags` | 100% | 100% |
| `path_matcher` | 0% | 97.3% |
| `enrollment` | 0% | 87.8% |
| `enrollment_alternatives` | 0% | 87.0% |
| `bpf_loader` | 0% | 80.1% |
| `process_tracker` | 0% | 66.1% |
| `bootstrap/main` | 0% | 44.6% |
| **total** | **7.65%** | **81.7%** |

134 tests with root, 87 without.

## Bug found: IP rules could be added but never removed

`add_ip_rule` wrote the address in **network** byte order:

```rust
let masked_bytes = masked_native.to_be_bytes();
key[4..8].copy_from_slice(&masked_bytes);
```

`remove_ip_rule` looked it up in **native** order:

```rust
key[4..8].copy_from_slice(&masked_ip.to_ne_bytes());
```

On little-endian those differ, so removal never matched and returned `ENOENT`.
Both now go through `codec::ip_rule_key`.

Neither function has a production caller today — rule removal is not wired into
the enrollment API — so this was latent rather than live. It would have
surfaced the moment it was wired up, which is exactly the kind of thing that is
easier to fix now than to debug later.

`parse_cidr` also now rejects a prefix length above 32; the inline version
accepted `/99` and shifted by a negative amount.

## Two behaviours pinned rather than fixed

Both are stubs, and the tests document them so a real implementation has to
update the test deliberately:

- **`get_process_info` returns `None` for every pid** — task storage is not
  readable from userspace. The socket `Query` path therefore always reports
  not-enrolled.
- **`validate_binary` reports every binary as unsigned** — enabling
  `require_signed_binary` today would deny all execs.

Neither is changed here; they are stated so they are not mistaken for working.

## CI

Adds a `root-integration` job. It prints kernel version, BTF presence and the
active LSM list before running, so a runner lacking them shows up in the log
rather than silently skipping every test.

## Not covered

`daemon/main.rs` (89 lines) is argument parsing and startup wiring, and
`bootstrap`'s `load_bpf_object`/`pin_all` also *attach* the LSM programs, which
needs `bpf` in the kernel's LSM list — that path is exercised on an LSM-enabled
host, not by these tests.
