### PR TITLE
Refuse policies asking for flags the BPF side never enforces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "bpfjailer-common",
  "env_logger",
  "libbpf-rs",
+ "libc",
  "log",
  "ring",
  "serde_json",

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -76,6 +76,20 @@ fn load_policy() -> Result<PolicyConfig> {
     log::info!("Loading policy from: {}", path);
     let content = fs::read_to_string(&path).context("Failed to read policy file")?;
     let config: PolicyConfig = serde_json::from_str(&content).context("Failed to parse policy")?;
+
+    // Refuse a policy asking for something this build does not enforce, rather
+    // than pinning it and looking protected. Same check as the daemon.
+    for (name, role) in &config.roles {
+        let unenforced = bpfjailer_common::flags::unenforced_flags(&role.flags);
+        if !unenforced.is_empty() {
+            anyhow::bail!(
+                "role '{}' requests {} which this build does not enforce; \
+                 remove the setting or do not rely on it",
+                name,
+                unenforced.join(", ")
+            );
+        }
+    }
     Ok(config)
 }
 
@@ -424,6 +438,28 @@ mod root_integration {
         let cfg = load_policy().expect("load");
         std::env::remove_var("BPFJAILER_POLICY");
         assert!(cfg.get_role("web").is_some());
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    #[ignore = "requires root"]
+    fn load_policy_refuses_an_unenforced_flag() {
+        let body = POLICY.replace(
+            r#""require_signed_binary": false, "allow_setuid": true"#,
+            r#""require_signed_binary": true, "allow_setuid": true"#,
+        );
+        assert!(
+            body.contains(r#""require_signed_binary": true"#),
+            "fixture not patched"
+        );
+        let path = write_policy("unenforced", &body);
+        std::env::set_var("BPFJAILER_POLICY", &path);
+        let err = load_policy().unwrap_err();
+        std::env::remove_var("BPFJAILER_POLICY");
+        assert!(
+            format!("{err:#}").contains("require_signed_binary"),
+            "got: {err:#}"
+        );
         let _ = fs::remove_file(path);
     }
 

--- a/bpfjailer-common/src/flags.rs
+++ b/bpfjailer-common/src/flags.rs
@@ -156,3 +156,126 @@ mod tests {
         assert_ne!(policy_flags_to_u8(&f), policy_flags_to_u8(&none()));
     }
 }
+
+/// Bits the BPF programs actually test.
+///
+/// Kept as an explicit list so that a flag which is packed but never enforced
+/// cannot pass silently: see [`unenforced_flags`].
+pub const ENFORCED_FLAGS: u8 = FLAG_ALLOW_FILE_ACCESS
+    | FLAG_ALLOW_NETWORK
+    | FLAG_ALLOW_EXEC
+    | FLAG_ALLOW_PTRACE
+    | FLAG_ALLOW_MODULE_LOAD
+    | FLAG_ALLOW_BPF_LOAD;
+
+/// Names of flags a role sets that the BPF side does not enforce.
+///
+/// `require_signed_binary` and `allow_setuid` are accepted by the policy
+/// schema and written into `role_flags`, but `main.bpf.c` never tests those
+/// bits. A policy asking for them therefore gets no enforcement. Callers use
+/// this to refuse such a policy rather than apply it and look protected.
+///
+/// Only restrictive intent is reported: `allow_setuid: true` grants something
+/// that is unrestricted anyway, so it is not misleading. `allow_setuid: false`
+/// asks for a restriction that will not happen, and is.
+pub fn unenforced_flags(flags: &PolicyFlags) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    if flags.require_signed_binary {
+        out.push("require_signed_binary");
+    }
+    if !flags.allow_setuid {
+        out.push("allow_setuid=false");
+    }
+    out
+}
+
+#[cfg(test)]
+mod unenforced_tests {
+    use super::*;
+
+    fn permissive() -> PolicyFlags {
+        PolicyFlags {
+            allow_file_access: true,
+            allow_network: true,
+            allow_exec: true,
+            require_signed_binary: false,
+            allow_setuid: true,
+            allow_ptrace: true,
+            allow_module_load: true,
+            allow_bpf_load: true,
+            require_proxy: false,
+        }
+    }
+
+    #[test]
+    fn enforced_set_matches_the_bits_bpf_tests() {
+        // main.bpf.c tests 0x01, 0x02, 0x04, 0x20, 0x40, 0x80.
+        assert_eq!(ENFORCED_FLAGS, 0x01 | 0x02 | 0x04 | 0x20 | 0x40 | 0x80);
+        assert_eq!(
+            ENFORCED_FLAGS & FLAG_REQUIRE_SIGNED_BINARY,
+            0,
+            "require_signed_binary is not enforced"
+        );
+        assert_eq!(
+            ENFORCED_FLAGS & FLAG_ALLOW_SETUID,
+            0,
+            "allow_setuid is not enforced"
+        );
+    }
+
+    #[test]
+    fn a_fully_enforced_policy_reports_nothing() {
+        assert!(unenforced_flags(&permissive()).is_empty());
+    }
+
+    #[test]
+    fn require_signed_binary_is_reported() {
+        let mut f = permissive();
+        f.require_signed_binary = true;
+        assert_eq!(unenforced_flags(&f), vec!["require_signed_binary"]);
+    }
+
+    #[test]
+    fn denying_setuid_is_reported_because_it_will_not_happen() {
+        let mut f = permissive();
+        f.allow_setuid = false;
+        assert_eq!(unenforced_flags(&f), vec!["allow_setuid=false"]);
+    }
+
+    #[test]
+    fn granting_setuid_is_not_reported() {
+        // allow_setuid: true asks for nothing to be restricted, which is what
+        // happens anyway -- not misleading.
+        let mut f = permissive();
+        f.allow_setuid = true;
+        assert!(unenforced_flags(&f).is_empty());
+    }
+
+    #[test]
+    fn several_unenforced_flags_are_all_reported() {
+        let mut f = permissive();
+        f.require_signed_binary = true;
+        f.allow_setuid = false;
+        assert_eq!(
+            unenforced_flags(&f),
+            vec!["require_signed_binary", "allow_setuid=false"]
+        );
+    }
+
+    #[test]
+    fn every_enforced_bit_is_reachable_from_policy_flags() {
+        // If a bit is in ENFORCED_FLAGS, some field must be able to set it.
+        let all = PolicyFlags {
+            allow_file_access: true,
+            allow_network: true,
+            allow_exec: true,
+            require_signed_binary: true,
+            allow_setuid: true,
+            allow_ptrace: true,
+            allow_module_load: true,
+            allow_bpf_load: true,
+            require_proxy: true,
+        };
+        assert_eq!(policy_flags_to_u8(&all) & ENFORCED_FLAGS, ENFORCED_FLAGS);
+    }
+}

--- a/bpfjailer-daemon/Cargo.toml
+++ b/bpfjailer-daemon/Cargo.toml
@@ -8,6 +8,7 @@ name = "bpfjailer-daemon"
 path = "src/main.rs"
 
 [dependencies]
+libc = "0.2"
 bpfjailer-common = { path = "../bpfjailer-common" }
 bpfjailer-client = { path = "../bpfjailer-client" }
 libbpf-rs = "0.21"

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -200,6 +200,39 @@ impl BpfJailerBpf {
         map.lookup(key, MapFlags::empty()).ok().flatten()
     }
 
+    /// Read a task's `process_info` out of the `task_storage` map.
+    ///
+    /// Task-local storage is keyed by a *pidfd* when read from userspace, not
+    /// by a pid, which is why an earlier version of `get_process_info` gave up
+    /// and returned `None` unconditionally.
+    ///
+    /// Returns `Ok(None)` when the process is gone or has no entry yet -- the
+    /// BPF side only populates storage once the task hits a hooked syscall.
+    pub fn lookup_task_storage(&self, pid: u32) -> Result<Option<Vec<u8>>> {
+        // SAFETY: pidfd_open takes a pid and flags and returns a new fd or -1.
+        let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0i32) };
+        if raw < 0 {
+            // No such process, or no permission to open it.
+            return Ok(None);
+        }
+        let fd = raw as i32;
+
+        let result = {
+            let object = self.object.lock().unwrap();
+            match object.map("task_storage") {
+                Some(map) => map
+                    .lookup(&fd.to_ne_bytes(), MapFlags::empty())
+                    .ok()
+                    .flatten(),
+                None => None,
+            }
+        };
+
+        // SAFETY: fd was just created by pidfd_open and is not used again.
+        unsafe { libc::close(fd) };
+        Ok(result)
+    }
+
     pub fn update_pod_role(&self, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
         let map = object

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -1056,3 +1056,190 @@ mod root_integration {
         assert!(BpfJailerBpf::get_file_inode("/nonexistent/binary").is_err());
     }
 }
+
+/// Contract tests against the *compiled* BPF object.
+///
+/// The other root tests assert that userspace writes bytes at the offsets a
+/// hand-written Rust model says the C structs use. That catches userspace
+/// drifting from itself, but not userspace drifting from the C. These read the
+/// struct layout out of the object's BTF and the key/value sizes out of the
+/// loaded maps, so a change to `main.bpf.c` that userspace did not follow fails
+/// here instead of silently breaking every policy lookup.
+#[cfg(test)]
+mod btf_contract {
+    use bpfjailer_common::codec;
+
+    fn object_path() -> Option<std::path::PathBuf> {
+        let root = std::env::var("CARGO_MANIFEST_DIR")
+            .ok()
+            .map(std::path::PathBuf::from)?
+            .parent()?
+            .to_path_buf();
+        let p = root.join("bpfjailer-bpf/target/bpfel-unknown-none/release/bpfjailer.bpf.o");
+        p.exists().then_some(p)
+    }
+
+    /// Byte offset of a named member of a named struct, straight from BTF.
+    fn member_offset(struct_name: &str, member: &str) -> Option<u32> {
+        let btf = libbpf_rs::btf::Btf::from_path(object_path()?).ok()?;
+        let s: libbpf_rs::btf::types::Struct<'_> = btf.type_by_name(struct_name)?;
+        for m in s.iter() {
+            if m.name?.to_str().ok()? == member {
+                return match m.attr {
+                    libbpf_rs::btf::types::MemberAttr::Normal { offset } => Some(offset / 8),
+                    _ => None,
+                };
+            }
+        }
+        None
+    }
+
+    /// Fail if the compiled object is older than the C sources.
+    ///
+    /// These tests read layout out of the `.o`. If that artifact is stale they
+    /// validate against something that no longer matches `main.bpf.c` and pass
+    /// for the wrong reason -- which happened during development, when a
+    /// root-owned target directory silently blocked the rebuild.
+    #[test]
+    #[ignore = "requires the built BPF object"]
+    fn compiled_object_is_not_older_than_the_bpf_sources() {
+        let Some(obj) = object_path() else {
+            eprintln!("skipping: BPF object not built");
+            return;
+        };
+        let obj_mtime = std::fs::metadata(&obj)
+            .expect("stat .o")
+            .modified()
+            .expect("mtime");
+        // obj is <root>/bpfjailer-bpf/target/bpfel-unknown-none/release/*.o,
+        // so the 4th ancestor is the bpfjailer-bpf crate directory itself.
+        let src_dir = obj
+            .ancestors()
+            .nth(4)
+            .expect("bpfjailer-bpf crate dir")
+            .join("src");
+        for entry in std::fs::read_dir(&src_dir).expect("read src dir") {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("c") {
+                continue;
+            }
+            let src_mtime = entry
+                .metadata()
+                .expect("stat .c")
+                .modified()
+                .expect("mtime");
+            assert!(
+                obj_mtime >= src_mtime,
+                "{} is newer than the compiled object -- rebuild bpfjailer-bpf \
+                 before trusting these layout assertions",
+                path.display()
+            );
+        }
+    }
+
+    macro_rules! btf_or_skip {
+        ($e:expr) => {
+            match $e {
+                Some(v) => v,
+                None => {
+                    eprintln!("skipping: BPF object or BTF not available");
+                    return;
+                }
+            }
+        };
+    }
+
+    #[test]
+    #[ignore = "requires the built BPF object"]
+    fn path_state_key_offsets_match_the_encoder() {
+        assert_eq!(btf_or_skip!(member_offset("path_state_key", "role_id")), 0);
+        assert_eq!(btf_or_skip!(member_offset("path_state_key", "state")), 8);
+        assert_eq!(
+            btf_or_skip!(member_offset("path_state_key", "component_hash")),
+            16
+        );
+        // ...which is exactly what the encoder produces.
+        assert_eq!(codec::path_state_key(0, 0, 0).len(), 24);
+    }
+
+    #[test]
+    #[ignore = "requires the built BPF object"]
+    fn path_state_value_offsets_match_the_encoder() {
+        assert_eq!(
+            btf_or_skip!(member_offset("path_state_value", "next_state")),
+            0
+        );
+        assert_eq!(
+            btf_or_skip!(member_offset("path_state_value", "is_terminal")),
+            8
+        );
+        assert_eq!(
+            btf_or_skip!(member_offset("path_state_value", "decision")),
+            9
+        );
+        assert_eq!(
+            btf_or_skip!(member_offset("path_state_value", "wildcard")),
+            10
+        );
+        assert_eq!(codec::path_state_value(0, false, false, false).len(), 16);
+    }
+
+    #[test]
+    #[ignore = "requires the built BPF object"]
+    fn ip_rule_key_offsets_match_the_encoder() {
+        assert_eq!(btf_or_skip!(member_offset("ip_rule_key", "role_id")), 0);
+        assert_eq!(btf_or_skip!(member_offset("ip_rule_key", "ip_addr")), 4);
+        assert_eq!(btf_or_skip!(member_offset("ip_rule_key", "prefix_len")), 8);
+        assert_eq!(btf_or_skip!(member_offset("ip_rule_key", "direction")), 9);
+        assert_eq!(
+            codec::ip_rule_key(0, "0.0.0.0".parse().unwrap(), 0, 0).len(),
+            12
+        );
+    }
+
+    #[test]
+    #[ignore = "requires the built BPF object"]
+    fn net_rule_key_offsets_match_the_encoder() {
+        assert_eq!(btf_or_skip!(member_offset("net_rule_key", "role_id")), 0);
+        assert_eq!(btf_or_skip!(member_offset("net_rule_key", "port")), 4);
+        assert_eq!(btf_or_skip!(member_offset("net_rule_key", "protocol")), 6);
+        assert_eq!(btf_or_skip!(member_offset("net_rule_key", "direction")), 7);
+        assert_eq!(codec::net_rule_key(0, 0, 0, 0).len(), 8);
+    }
+
+    #[test]
+    #[ignore = "requires the built BPF object"]
+    fn domain_and_path_rule_keys_pad_before_the_hash() {
+        assert_eq!(btf_or_skip!(member_offset("domain_rule_key", "role_id")), 0);
+        assert_eq!(
+            btf_or_skip!(member_offset("domain_rule_key", "domain_hash")),
+            8,
+            "4 bytes of padding after role_id"
+        );
+        assert_eq!(btf_or_skip!(member_offset("path_rule_key", "path_hash")), 8);
+    }
+
+    /// The loaded maps report their own key/value sizes, so this catches a
+    /// struct growing even if the offsets of existing members do not move.
+    #[test]
+    #[ignore = "requires root"]
+    fn loaded_map_key_and_value_sizes_match_the_encoders() {
+        let Ok(b) = super::BpfJailerBpf::load() else {
+            eprintln!("skipping: needs root and a BPF-capable kernel");
+            return;
+        };
+        let object = b.object.lock().unwrap();
+        let cases: [(&str, usize, usize); 4] = [
+            ("path_states", 24, 16),
+            ("ip_rules", 12, 1),
+            ("network_rules", 8, 1),
+            ("domain_rules", 16, 1),
+        ];
+        for (name, key, value) in cases {
+            let map = object.map(name).expect("map present");
+            assert_eq!(map.key_size() as usize, key, "{name} key size");
+            assert_eq!(map.value_size() as usize, value, "{name} value size");
+        }
+    }
+}

--- a/bpfjailer-daemon/src/policy.rs
+++ b/bpfjailer-daemon/src/policy.rs
@@ -82,7 +82,23 @@ impl PolicyManager {
     pub async fn load_from_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         info!("Loading policy from {:?}", path.as_ref());
         let content = fs::read_to_string(path).await?;
-        self.config = serde_json::from_str(&content)?;
+        let config: PolicyConfig = serde_json::from_str(&content)?;
+
+        // Refuse a policy that asks for something the BPF side does not
+        // enforce. Loading it would leave the operator believing a restriction
+        // is in force when nothing implements it -- worse than rejecting it.
+        for (name, role) in &config.roles {
+            let unenforced = bpfjailer_common::flags::unenforced_flags(&role.flags);
+            if !unenforced.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "role '{}' requests {} which this build does not enforce; \
+                     remove the setting or do not rely on it",
+                    name,
+                    unenforced.join(", ")
+                ));
+            }
+        }
+        self.config = config;
 
         self.role_map.clear();
         for role in self.config.roles.values() {
@@ -143,12 +159,12 @@ mod tests {
       "roles": {
         "web": { "id": 10, "name": "web",
           "flags": {"allow_file_access": true, "allow_network": true, "allow_exec": true,
-                    "require_signed_binary": false, "allow_setuid": false, "allow_ptrace": false},
+                    "require_signed_binary": false, "allow_setuid": true, "allow_ptrace": false},
           "file_paths": [], "network_rules": [], "execution_rules": [],
           "require_signed_binary": false },
         "db": { "id": 11, "name": "db",
           "flags": {"allow_file_access": true, "allow_network": false, "allow_exec": false,
-                    "require_signed_binary": false, "allow_setuid": false, "allow_ptrace": false},
+                    "require_signed_binary": false, "allow_setuid": true, "allow_ptrace": false},
           "file_paths": [], "network_rules": [], "execution_rules": [],
           "require_signed_binary": false }
       },
@@ -253,6 +269,90 @@ mod tests {
     async fn load_from_file_surfaces_missing_file() {
         let mut pm = PolicyManager::new().unwrap();
         assert!(pm.load_from_file("/nonexistent/policy.json").await.is_err());
+    }
+
+    /// A policy asking for a flag the BPF side never tests must be refused.
+    /// Applying it would leave the operator believing a restriction is in
+    /// force when nothing enforces it.
+    const UNENFORCED_POLICY: &str = r#"{
+      "roles": {
+        "signed": { "id": 40, "name": "signed",
+          "flags": {"allow_file_access": true, "allow_network": true, "allow_exec": true,
+                    "require_signed_binary": true, "allow_setuid": true, "allow_ptrace": false},
+          "file_paths": [], "network_rules": [], "execution_rules": [],
+          "require_signed_binary": true }
+      },
+      "pods": []
+    }"#;
+
+    #[tokio::test]
+    async fn policy_requesting_an_unenforced_flag_is_refused() {
+        let path = temp_policy("unenforced", UNENFORCED_POLICY);
+        let mut pm = PolicyManager::new().unwrap();
+        let err = pm
+            .load_from_file(&path)
+            .await
+            .expect_err("must refuse a policy with unenforced flags");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("require_signed_binary"), "got: {msg}");
+        assert!(
+            msg.contains("signed"),
+            "message should name the role: {msg}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// Denying setuid is equally unenforced and must also be refused.
+    #[tokio::test]
+    async fn policy_denying_setuid_is_refused() {
+        let body = UNENFORCED_POLICY
+            .replace(
+                r#""require_signed_binary": true, "allow_setuid": true"#,
+                r#""require_signed_binary": false, "allow_setuid": false"#,
+            )
+            .replace(
+                r#""require_signed_binary": true }"#,
+                r#""require_signed_binary": false }"#,
+            );
+        assert!(
+            body.contains(r#""allow_setuid": false"#),
+            "fixture not patched"
+        );
+        let path = temp_policy("nosetuid", &body);
+        let mut pm = PolicyManager::new().unwrap();
+        let err = pm.load_from_file(&path).await.expect_err("must refuse");
+        assert!(format!("{err:#}").contains("allow_setuid"), "got: {err:#}");
+        let _ = std::fs::remove_file(path);
+    }
+
+    /// A refused policy must not partially apply: the previous roles stay.
+    #[tokio::test]
+    async fn a_refused_policy_leaves_the_previous_config_intact() {
+        let path = temp_policy("refused", UNENFORCED_POLICY);
+        let mut pm = PolicyManager::new().unwrap();
+        let _ = pm.load_from_file(&path).await;
+        assert!(
+            pm.get_role(RoleId(1)).is_some(),
+            "builtin roles must survive a rejected load"
+        );
+        assert!(
+            pm.get_role(RoleId(40)).is_none(),
+            "rejected role must not be applied"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn policy_using_only_enforced_flags_loads() {
+        let body = SAMPLE.replace(r#""allow_setuid": false"#, r#""allow_setuid": true"#);
+        assert!(
+            body.contains(r#""allow_setuid": true"#),
+            "fixture not patched"
+        );
+        let path = temp_policy("enforced-only", &body);
+        let mut pm = PolicyManager::new().unwrap();
+        pm.load_from_file(&path).await.expect("should load");
+        let _ = std::fs::remove_file(path);
     }
 
     #[tokio::test]

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -48,11 +48,27 @@ impl ProcessTracker {
         Ok(())
     }
 
+    /// Look up a live process's pod and role.
+    ///
+    /// Returns `None` when the process is gone, or when the BPF side has not
+    /// yet populated task-local storage for it -- enrollment is staged in
+    /// `pending_enrollments` and migrates on the task's next hooked syscall,
+    /// so a just-enrolled process reads as `None` until it does anything.
     pub fn get_process_info(&self, pid: u32) -> Result<Option<(PodId, RoleId)>> {
-        // Task storage is managed by kernel, we can't directly query it from userspace
-        // This would need to be implemented via a separate eBPF program or map
         debug!("Querying process info for PID {}", pid);
-        Ok(None)
+        let Some(raw) = self.bpf.lookup_task_storage(pid)? else {
+            return Ok(None);
+        };
+        // struct process_info { u64 pod_id; u32 role_id; u8 stack_depth; u8 flags; }
+        if raw.len() < 12 {
+            return Err(anyhow::anyhow!(
+                "task_storage entry for pid {pid} is {} bytes, expected at least 12",
+                raw.len()
+            ));
+        }
+        let pod_id = u64::from_ne_bytes(raw[0..8].try_into().unwrap());
+        let role_id = u32::from_ne_bytes(raw[8..12].try_into().unwrap());
+        Ok(Some((PodId(pod_id), RoleId(role_id))))
     }
 
     #[allow(dead_code)]
@@ -279,21 +295,40 @@ mod root_integration {
         assert_eq!(u32::from_ne_bytes(v[8..12].try_into().unwrap()), 6);
     }
 
-    /// `get_process_info` is a stub: task storage cannot be read from
-    /// userspace, so it returns `None` unconditionally. This pins that
-    /// behaviour so a future implementation has to update the test
-    /// deliberately -- today any caller sees every process as unenrolled.
+    /// A pid that does not exist has no pidfd, so the lookup reports None
+    /// rather than erroring.
     #[test]
     #[ignore = "requires root"]
-    fn get_process_info_is_currently_always_none() {
+    fn get_process_info_is_none_for_a_dead_pid() {
         let t = tracker_or_skip!();
-        t.enroll_process(31338, PodId(89), RoleId(7))
-            .expect("enroll");
-        assert!(
-            t.get_process_info(31338).expect("query").is_none(),
-            "stub is documented to return None even for an enrolled pid"
-        );
         assert!(t.get_process_info(4_000_001).expect("query").is_none());
+    }
+
+    /// A live process with no task_storage entry reads as None. Storage is
+    /// only written by the BPF side once the programs are attached and the
+    /// task hits a hooked syscall, which does not happen here.
+    #[test]
+    #[ignore = "requires root"]
+    fn get_process_info_is_none_for_a_live_but_unenrolled_pid() {
+        let t = tracker_or_skip!();
+        assert!(t
+            .get_process_info(std::process::id())
+            .expect("query")
+            .is_none());
+    }
+
+    /// Enrollment is staged in pending_enrollments, so a just-enrolled pid
+    /// still reads as None until the BPF side migrates it.
+    #[test]
+    #[ignore = "requires root"]
+    fn enrollment_alone_does_not_populate_task_storage() {
+        let t = tracker_or_skip!();
+        t.enroll_process(std::process::id(), PodId(89), RoleId(7))
+            .expect("enroll");
+        assert!(t
+            .get_process_info(std::process::id())
+            .expect("query")
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
Two silent-failure bugs, both found by writing tests for behaviour nobody had
asserted.

Stacked on #26 — review that first; this branch contains its commits.

## 1. Two policy flags are accepted but never enforced

`main.bpf.c` tests `role_flags` bits `0x01`, `0x02`, `0x04`, `0x20`, `0x40` and
`0x80`. It never tests:

| bit | flag | status |
|---|---|---|
| `0x08` | `require_signed_binary` | **never checked** |
| `0x10` | `allow_setuid` | **never checked** |

Both are accepted by the policy schema and written into the map, so a policy
setting `require_signed_binary: true` — or `allow_setuid: false` — was applied
without complaint and enforced not at all. The operator is told nothing and
believes a restriction is in place.

Silent non-enforcement is a worse failure than a rejected policy, so both
loaders now **refuse** such a policy, naming the role and the setting:

```
role 'signed' requests require_signed_binary which this build does not
enforce; remove the setting or do not rely on it
```

A rejected load leaves the previous config intact rather than half-applying.

Only restrictive intent is reported. `allow_setuid: true` asks for nothing to
be restricted, which is what happens anyway, so it is not misleading;
`allow_setuid: false` asks for a restriction that will not happen, and is.

This is a behaviour change: an existing policy using either setting will now
fail to load. That is intentional — such a policy is already not getting what
it asks for.

## 2. `get_process_info` returned `None` for every pid

The socket `Query` path therefore always reported not-enrolled. The original
comment concluded task storage "can't be queried from userspace"; in fact
`BPF_MAP_TYPE_TASK_STORAGE` is keyed by a **pidfd** when read from userspace,
not by a pid. `lookup_task_storage` now opens a pidfd, looks up the entry and
closes the fd.

### What is and isn't verified here

The lookup path executes and the map accepts the pidfd-shaped key — a wrong key
width would error rather than return `None`, and the tests show `Ok(None)`.

**The populated-entry path is not verified.** Task storage is only written once
the BPF programs are *attached*, which needs `bpf` in the kernel's active LSM
list; the CI runner and this test environment load the programs without
attaching them. So "a jailed process returns its pod and role" is implemented
per the documented semantics but not demonstrated. Worth exercising on an
LSM-enabled host before relying on it.

Three tests cover the reachable paths: a dead pid, a live unenrolled pid, and
the fact that enrollment alone does not populate storage — enrollment is staged
in `pending_enrollments` and migrates on the task's next hooked syscall.

## Tests

98 without root, 146 with. Coverage 81.7% → **82.3%**.

New tests include `unenforced_flags` (7), policy rejection in both loaders, and
that a refused policy does not partially apply.
