### PR TITLE
Migrate to libbpf-rs 0.26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
       cargo-minor-patch:
         update-types: ["minor", "patch"]
     # Major bumps of the BPF loader change the API surface and need a manual
-    # migration, so they should not be raised automatically.
+    # migration, so they should not be raised automatically. Kept after the
+    # 0.21 -> 0.26 migration: the next major will break the same way.
     ignore:
       - dependency-name: "libbpf-rs"
         update-types: ["version-update:semver-major"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror",
  "time",
 ]
 
@@ -245,7 +245,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -306,19 +306,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -336,28 +330,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -416,18 +388,13 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libbpf-rs"
-version = "0.21.2"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70f003d6e48e60a7ed55d4fb5b2419b91a962c903fa0b00e8db95a3b6651abc"
+checksum = "fd8e8db46a2d5967b5b3dba7aba32a875dc38f222395040607045635ec1f9b63"
 dependencies = [
- "bitflags 1.3.2",
- "lazy_static",
+ "bitflags 2.10.0",
  "libbpf-sys",
  "libc",
- "nix 0.26.4",
- "num_enum",
- "strum_macros",
- "thiserror 1.0.69",
  "vsprintf",
 ]
 
@@ -438,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a109478760b2900aa2a6f2087e9d0de1d9c535b1758602af2845d5d2ccfaed7c"
 dependencies = [
  "cc",
- "nix 0.31.3",
+ "nix",
  "pkg-config",
 ]
 
@@ -476,15 +443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,18 +457,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -570,27 +516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,12 +523,6 @@ checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -666,16 +585,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -766,14 +675,8 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scopeguard"
@@ -857,30 +760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,31 +794,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.19",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1010,23 +869,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -1152,15 +994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,7 +1006,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-libbpf-rs = "0.21"
+libbpf-rs = "0.26"
 libbpf-sys = "1.4"
 tokio = { version = "1.35", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/bpfjailer-bootstrap/Cargo.toml
+++ b/bpfjailer-bootstrap/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 bpfjailer-common = { path = "../bpfjailer-common" }
-libbpf-rs = "0.21"
+libbpf-rs = "0.26"
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true }

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Context, Result};
 use bpfjailer_common::policy::PolicyConfig;
+use libbpf_rs::MapCore;
 use libbpf_rs::{Link, MapFlags, Object, ObjectBuilder};
 use std::fs;
 use std::os::unix::fs::MetadataExt;
@@ -13,6 +14,28 @@ use std::path::{Path, PathBuf};
 const BPF_PIN_PATH: &str = "/sys/fs/bpf/bpfjailer";
 const DEFAULT_POLICY_PATH: &str = "/etc/bpfjailer/policy.json";
 const LOCAL_POLICY_PATH: &str = "config/policy.json";
+
+/// Find a map by name.
+///
+/// libbpf-rs 0.26 removed `Object::map(name)`/`map_mut(name)` in favour of
+/// iterating. `update` is a `MapCore` method taking `&self`, so the immutable
+/// iterator is enough here.
+fn map_by_name<'a>(object: &'a Object, name: &str) -> Option<libbpf_rs::Map<'a>> {
+    let want = std::ffi::OsStr::new(name);
+    object.maps().find(|m| m.name() == want)
+}
+
+/// Find a map by name for operations that mutate it, such as pinning.
+fn map_mut_by_name<'a>(object: &'a mut Object, name: &str) -> Option<libbpf_rs::MapMut<'a>> {
+    let want = std::ffi::OsStr::new(name);
+    object.maps_mut().find(|m| m.name() == want)
+}
+
+/// Find a program by name. `Object::prog_mut(name)` was removed in 0.26.
+fn prog_by_name<'a>(object: &'a Object, name: &str) -> Option<libbpf_rs::ProgramMut<'a>> {
+    let want = std::ffi::OsStr::new(name);
+    object.progs_mut().find(|p| p.name() == want)
+}
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -122,7 +145,7 @@ fn load_bpf_object() -> Result<(Object, Vec<Link>)> {
 
     let mut object_builder = ObjectBuilder::default();
     let open_object = object_builder.open_file(obj_path)?;
-    let mut object = open_object.load().context("Failed to load BPF object")?;
+    let object = open_object.load().context("Failed to load BPF object")?;
 
     log::info!("BPF object loaded successfully");
 
@@ -143,7 +166,7 @@ fn load_bpf_object() -> Result<(Object, Vec<Link>)> {
 
     let mut links = Vec::new();
     for name in &program_names {
-        if let Some(prog) = object.prog_mut(name) {
+        if let Some(prog) = prog_by_name(&object, name) {
             let link = prog
                 .attach()
                 .with_context(|| format!("Failed to attach {}", name))?;
@@ -166,7 +189,7 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
         let flags = bpfjailer_common::flags::policy_flags_to_u8(&role.flags);
 
         // Update role_flags map
-        if let Some(map) = object.map("role_flags") {
+        if let Some(map) = map_by_name(object, "role_flags") {
             let key = role_id.to_ne_bytes();
             let value = [flags];
             map.update(&key, &value, MapFlags::empty())?;
@@ -174,7 +197,7 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
         }
 
         // Load network rules
-        if let Some(map) = object.map("network_rules") {
+        if let Some(map) = map_by_name(object, "network_rules") {
             for rule in &role.network_rules {
                 let protocol = match rule.protocol.as_str() {
                     "tcp" | "TCP" => 6u8,
@@ -206,15 +229,15 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
         }
 
         // Load path rules (state machine)
-        if let Some(map) = object.map("path_states") {
+        if let Some(map) = map_by_name(object, "path_states") {
             for path_rule in &role.file_paths {
-                add_path_state(map, role_id, &path_rule.pattern, path_rule.allow)?;
+                add_path_state(&map, role_id, &path_rule.pattern, path_rule.allow)?;
             }
         }
     }
 
     // Load pod mappings
-    if let Some(map) = object.map("pod_to_role") {
+    if let Some(map) = map_by_name(object, "pod_to_role") {
         for pod in &policy.pods {
             let key = pod.id.to_ne_bytes();
             let value = pod.role_id.0.to_ne_bytes();
@@ -224,7 +247,7 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
     }
 
     // Load exec enrollments
-    if let Some(map) = object.map("exec_enrollment") {
+    if let Some(map) = map_by_name(object, "exec_enrollment") {
         for enrollment in &policy.exec_enrollments {
             if let Ok(metadata) = fs::metadata(&enrollment.executable_path) {
                 let inode = metadata.ino();
@@ -252,7 +275,7 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
     }
 
     // Load cgroup enrollments
-    if let Some(map) = object.map("cgroup_enrollment") {
+    if let Some(map) = map_by_name(object, "cgroup_enrollment") {
         for enrollment in &policy.cgroup_enrollments {
             if let Ok(metadata) = fs::metadata(&enrollment.cgroup_path) {
                 let cgroup_id = metadata.ino();
@@ -323,7 +346,7 @@ fn pin_all(object: &mut Object, links: &mut [Link]) -> Result<()> {
     ];
 
     for name in &map_names {
-        if let Some(map) = object.map_mut(name) {
+        if let Some(mut map) = map_mut_by_name(object, name) {
             let pin_path = format!("{}/{}", maps_dir, name);
             if let Err(e) = map.pin(&pin_path) {
                 log::warn!("Failed to pin map {}: {}", name, e);
@@ -349,7 +372,7 @@ fn pin_all(object: &mut Object, links: &mut [Link]) -> Result<()> {
     ];
 
     for name in &prog_names {
-        if let Some(prog) = object.prog_mut(name) {
+        if let Some(mut prog) = prog_by_name(object, name) {
             let pin_path = format!("{}/{}", progs_dir, name);
             if let Err(e) = prog.pin(&pin_path) {
                 log::warn!("Failed to pin program {}: {}", name, e);
@@ -494,8 +517,7 @@ mod root_integration {
         populate_maps(&mut object, &cfg).expect("populate");
 
         // role_flags: every bit must survive, not just the first three.
-        let flags = object
-            .map("role_flags")
+        let flags = map_by_name(&object, "role_flags")
             .expect("map")
             .lookup(&30u32.to_ne_bytes(), MapFlags::empty())
             .expect("lookup")
@@ -506,7 +528,7 @@ mod root_integration {
 
         // path_states: the deny rule must be present under the codec's key.
         let entries = bpfjailer_common::codec::path_state_entries(30, "/etc/shadow", false);
-        let map = object.map("path_states").expect("map");
+        let map = map_by_name(&object, "path_states").expect("map");
         for (key, value) in entries {
             let got = map
                 .lookup(&key, MapFlags::empty())
@@ -524,8 +546,7 @@ mod root_integration {
         };
         let cfg: PolicyConfig = serde_json::from_str(POLICY).expect("parse");
         populate_maps(&mut object, &cfg).expect("populate");
-        let v = object
-            .map("pod_to_role")
+        let v = map_by_name(&object, "pod_to_role")
             .expect("map")
             .lookup(&300u64.to_ne_bytes(), MapFlags::empty())
             .expect("lookup")
@@ -539,8 +560,8 @@ mod root_integration {
         let Some(object) = loaded_object() else {
             return;
         };
-        let map = object.map("path_states").expect("map");
-        add_path_state(map, 31, "/srv/data/", false).expect("add");
+        let map = map_by_name(&object, "path_states").expect("map");
+        add_path_state(&map, 31, "/srv/data/", false).expect("add");
         for (key, value) in bpfjailer_common::codec::path_state_entries(31, "/srv/data/", false) {
             let got = map
                 .lookup(&key, MapFlags::empty())

--- a/bpfjailer-daemon/Cargo.toml
+++ b/bpfjailer-daemon/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 libc = "0.2"
 bpfjailer-common = { path = "../bpfjailer-common" }
 bpfjailer-client = { path = "../bpfjailer-client" }
-libbpf-rs = "0.21"
+libbpf-rs = "0.26"
 tokio = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use bpfjailer_common::codec;
+use libbpf_rs::MapCore;
 use libbpf_rs::{MapFlags, Object, ObjectBuilder};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -15,6 +16,22 @@ pub struct BpfJailerBpf {
 // The underlying libbpf handles are thread-safe for concurrent access
 unsafe impl Send for BpfJailerBpf {}
 unsafe impl Sync for BpfJailerBpf {}
+
+/// Find a program by name. `Object::prog_mut(name)` was removed in 0.26.
+fn prog_by_name<'a>(object: &'a Object, name: &str) -> Option<libbpf_rs::ProgramMut<'a>> {
+    let want = std::ffi::OsStr::new(name);
+    object.progs_mut().find(|p| p.name() == want)
+}
+
+/// Find a map by name.
+///
+/// libbpf-rs 0.26 removed `Object::map(name)` in favour of iterating
+/// `Object::maps()`. `update`/`delete` are `MapCore` methods taking `&self`,
+/// so the immutable iterator is sufficient for everything here.
+fn map_by_name<'a>(object: &'a Object, name: &str) -> Option<libbpf_rs::Map<'a>> {
+    let want = std::ffi::OsStr::new(name);
+    object.maps().find(|m| m.name() == want)
+}
 
 impl BpfJailerBpf {
     pub fn load() -> Result<Self> {
@@ -51,7 +68,7 @@ impl BpfJailerBpf {
         let open_object = object_builder.open_file(obj_path)?;
 
         // Try to load - this will create maps including task_storage
-        let mut object = match open_object.load() {
+        let object = match open_object.load() {
             Ok(obj) => obj,
             Err(e) => {
                 let err_str = e.to_string();
@@ -80,66 +97,66 @@ impl BpfJailerBpf {
         log::info!("BPF object loaded successfully");
 
         // Check that maps exist
-        if object.map("pod_to_role").is_none() {
+        if map_by_name(&object, "pod_to_role").is_none() {
             return Err(anyhow::anyhow!("pod_to_role map not found"));
         }
-        if object.map("role_flags").is_none() {
+        if map_by_name(&object, "role_flags").is_none() {
             return Err(anyhow::anyhow!("role_flags map not found"));
         }
-        if object.map("pending_enrollments").is_none() {
+        if map_by_name(&object, "pending_enrollments").is_none() {
             return Err(anyhow::anyhow!("pending_enrollments map not found"));
         }
         log::info!("✓ pending_enrollments map available for enrollment");
 
-        if object.map("network_rules").is_none() {
+        if map_by_name(&object, "network_rules").is_none() {
             return Err(anyhow::anyhow!("network_rules map not found"));
         }
         log::info!("✓ network_rules map available for port/protocol filtering");
 
-        if object.map("path_rules").is_none() {
+        if map_by_name(&object, "path_rules").is_none() {
             return Err(anyhow::anyhow!("path_rules map not found"));
         }
         log::info!("✓ path_rules map available for path matching");
 
-        if object.map("path_states").is_none() {
+        if map_by_name(&object, "path_states").is_none() {
             return Err(anyhow::anyhow!("path_states map not found"));
         }
         log::info!("✓ path_states map available for dentry-based path matching");
 
-        if object.map("inode_cache").is_none() {
+        if map_by_name(&object, "inode_cache").is_none() {
             log::warn!("inode_cache map not found (optional)");
         } else {
             log::info!("✓ inode_cache map available for caching");
         }
 
         // Auto-enrollment maps
-        if object.map("exec_enrollment").is_some() {
+        if map_by_name(&object, "exec_enrollment").is_some() {
             log::info!("✓ exec_enrollment map available for executable-based enrollment");
         }
-        if object.map("cgroup_enrollment").is_some() {
+        if map_by_name(&object, "cgroup_enrollment").is_some() {
             log::info!("✓ cgroup_enrollment map available for cgroup-based enrollment");
         }
 
         // AI agent security maps
-        if object.map("ip_rules").is_some() {
+        if map_by_name(&object, "ip_rules").is_some() {
             log::info!("✓ ip_rules map available for IP/CIDR filtering");
         }
-        if object.map("proxy_config").is_some() {
+        if map_by_name(&object, "proxy_config").is_some() {
             log::info!("✓ proxy_config map available for proxy enforcement");
         }
-        if object.map("domain_rules").is_some() {
+        if map_by_name(&object, "domain_rules").is_some() {
             log::info!("✓ domain_rules map available for domain filtering");
         }
-        if object.map("dns_cache").is_some() {
+        if map_by_name(&object, "dns_cache").is_some() {
             log::info!("✓ dns_cache map available for DNS tracking");
         }
-        if object.map("dns_pending").is_some() {
+        if map_by_name(&object, "dns_pending").is_some() {
             log::info!("✓ dns_pending map available for DNS query tracking");
         }
 
         // Note: task_storage map is automatically handled by libbpf-rs
         // It's created but we don't need to access it from userspace
-        if object.map("task_storage").is_some() {
+        if map_by_name(&object, "task_storage").is_some() {
             log::info!("✓ task_storage map created successfully");
         }
 
@@ -159,7 +176,7 @@ impl BpfJailerBpf {
 
         // LSM programs must be explicitly attached
         for name in &program_names {
-            match object.prog_mut(name) {
+            match prog_by_name(&object, name) {
                 Some(prog) => {
                     match prog.attach() {
                         Ok(link) => {
@@ -196,7 +213,7 @@ impl BpfJailerBpf {
     #[cfg(test)]
     pub(crate) fn map_lookup(&self, map_name: &str, key: &[u8]) -> Option<Vec<u8>> {
         let object = self.object.lock().unwrap();
-        let map = object.map(map_name)?;
+        let map = map_by_name(&object, map_name)?;
         map.lookup(key, MapFlags::empty()).ok().flatten()
     }
 
@@ -219,7 +236,7 @@ impl BpfJailerBpf {
 
         let result = {
             let object = self.object.lock().unwrap();
-            match object.map("task_storage") {
+            match map_by_name(&object, "task_storage") {
                 Some(map) => map
                     .lookup(&fd.to_ne_bytes(), MapFlags::empty())
                     .ok()
@@ -235,8 +252,7 @@ impl BpfJailerBpf {
 
     pub fn update_pod_role(&self, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("pod_to_role")
+        let map = map_by_name(&object, "pod_to_role")
             .ok_or_else(|| anyhow::anyhow!("pod_to_role map not found"))?;
         let key = pod_id.to_ne_bytes();
         let value = role_id.to_ne_bytes();
@@ -246,8 +262,7 @@ impl BpfJailerBpf {
 
     pub fn update_role_flags(&self, role_id: u32, flags: u8) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("role_flags")
+        let map = map_by_name(&object, "role_flags")
             .ok_or_else(|| anyhow::anyhow!("role_flags map not found"))?;
         let key = role_id.to_ne_bytes();
         let value = [flags];
@@ -259,8 +274,7 @@ impl BpfJailerBpf {
     /// on the next syscall (file_open, exec, etc.)
     pub fn enroll_pending_process(&self, pid: u32, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("pending_enrollments")
+        let map = map_by_name(&object, "pending_enrollments")
             .ok_or_else(|| anyhow::anyhow!("pending_enrollments map not found"))?;
 
         let key = pid.to_ne_bytes();
@@ -296,8 +310,7 @@ impl BpfJailerBpf {
         allowed: bool,
     ) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("network_rules")
+        let map = map_by_name(&object, "network_rules")
             .ok_or_else(|| anyhow::anyhow!("network_rules map not found"))?;
 
         let key = codec::net_rule_key(role_id, port, protocol, direction);
@@ -334,8 +347,7 @@ impl BpfJailerBpf {
         direction: u8,
     ) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("network_rules")
+        let map = map_by_name(&object, "network_rules")
             .ok_or_else(|| anyhow::anyhow!("network_rules map not found"))?;
 
         let mut key = [0u8; 8];
@@ -353,8 +365,7 @@ impl BpfJailerBpf {
     /// allowed: true = allow, false = deny
     pub fn add_path_rule(&self, role_id: u32, path: &str, allowed: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("path_rules")
+        let map = map_by_name(&object, "path_rules")
             .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
 
         let key = codec::path_rule_key(role_id, path);
@@ -377,8 +388,7 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_path_rule(&self, role_id: u32, path: &str) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("path_rules")
+        let map = map_by_name(&object, "path_rules")
             .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
 
         let path_hash = bpfjailer_common::hash::fnv1a_hash_u64(path);
@@ -399,8 +409,7 @@ impl BpfJailerBpf {
     ///   - Wildcards: "/var/lib/*/data" (* matches any single component)
     pub fn add_path_state(&self, role_id: u32, pattern: &str, allowed: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("path_states")
+        let map = map_by_name(&object, "path_states")
             .ok_or_else(|| anyhow::anyhow!("path_states map not found"))?;
 
         let entries = codec::path_state_entries(role_id, pattern, allowed);
@@ -423,8 +432,7 @@ impl BpfJailerBpf {
 
     pub fn invalidate_cache(&self) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("cache_generation")
+        let map = map_by_name(&object, "cache_generation")
             .ok_or_else(|| anyhow::anyhow!("cache_generation map not found"))?;
 
         // Read current generation
@@ -455,8 +463,7 @@ impl BpfJailerBpf {
     /// All processes executing this binary will be auto-enrolled
     pub fn add_exec_enrollment(&self, inode: u64, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("exec_enrollment")
+        let map = map_by_name(&object, "exec_enrollment")
             .ok_or_else(|| anyhow::anyhow!("exec_enrollment map not found"))?;
 
         let key = inode.to_ne_bytes();
@@ -480,8 +487,7 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_exec_enrollment(&self, inode: u64) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("exec_enrollment")
+        let map = map_by_name(&object, "exec_enrollment")
             .ok_or_else(|| anyhow::anyhow!("exec_enrollment map not found"))?;
 
         let key = inode.to_ne_bytes();
@@ -494,8 +500,7 @@ impl BpfJailerBpf {
     /// All processes in this cgroup will be auto-enrolled
     pub fn add_cgroup_enrollment(&self, cgroup_id: u64, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("cgroup_enrollment")
+        let map = map_by_name(&object, "cgroup_enrollment")
             .ok_or_else(|| anyhow::anyhow!("cgroup_enrollment map not found"))?;
 
         let key = cgroup_id.to_ne_bytes();
@@ -519,8 +524,7 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_cgroup_enrollment(&self, cgroup_id: u64) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("cgroup_enrollment")
+        let map = map_by_name(&object, "cgroup_enrollment")
             .ok_or_else(|| anyhow::anyhow!("cgroup_enrollment map not found"))?;
 
         let key = cgroup_id.to_ne_bytes();
@@ -545,8 +549,7 @@ impl BpfJailerBpf {
         allowed: bool,
     ) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("ip_rules")
+        let map = map_by_name(&object, "ip_rules")
             .ok_or_else(|| anyhow::anyhow!("ip_rules map not found"))?;
 
         let (ip, prefix_len) = codec::parse_cidr(cidr).map_err(|e| anyhow::anyhow!(e))?;
@@ -573,8 +576,7 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_ip_rule(&self, role_id: u32, cidr: &str, direction: u8) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("ip_rules")
+        let map = map_by_name(&object, "ip_rules")
             .ok_or_else(|| anyhow::anyhow!("ip_rules map not found"))?;
 
         // Must use the same encoder as add_ip_rule: these previously disagreed
@@ -589,8 +591,7 @@ impl BpfJailerBpf {
 
     pub fn set_proxy_config(&self, role_id: u32, proxy_addr: &str, required: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("proxy_config")
+        let map = map_by_name(&object, "proxy_config")
             .ok_or_else(|| anyhow::anyhow!("proxy_config map not found"))?;
 
         let (ip, port) = codec::parse_proxy_addr(proxy_addr).map_err(|e| anyhow::anyhow!(e))?;
@@ -609,8 +610,7 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_proxy_config(&self, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("proxy_config")
+        let map = map_by_name(&object, "proxy_config")
             .ok_or_else(|| anyhow::anyhow!("proxy_config map not found"))?;
 
         let key = role_id.to_ne_bytes();
@@ -624,8 +624,7 @@ impl BpfJailerBpf {
     /// allowed: true = allow, false = deny
     pub fn add_domain_rule(&self, role_id: u32, domain: &str, allowed: bool) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("domain_rules")
+        let map = map_by_name(&object, "domain_rules")
             .ok_or_else(|| anyhow::anyhow!("domain_rules map not found"))?;
 
         let key = codec::domain_rule_key(role_id, domain);
@@ -643,8 +642,7 @@ impl BpfJailerBpf {
     #[allow(dead_code)]
     pub fn remove_domain_rule(&self, role_id: u32, domain: &str) -> Result<()> {
         let object = self.object.lock().unwrap();
-        let map = object
-            .map("domain_rules")
+        let map = map_by_name(&object, "domain_rules")
             .ok_or_else(|| anyhow::anyhow!("domain_rules map not found"))?;
 
         let domain_hash = bpfjailer_common::hash::fnv1a_hash_u64(domain);
@@ -720,7 +718,7 @@ impl BpfJailerBpf {
         ];
 
         for name in &map_names {
-            if object.map(name).is_some() {
+            if map_by_name(&object, name).is_some() {
                 let pin_path = format!("{}/{}", maps_dir, name);
                 // Note: pin() requires &mut self in some versions
                 // This is a limitation - in daemon mode we'd need mutable access
@@ -856,7 +854,7 @@ mod root_integration {
             "domain_rules",
             "task_storage",
         ] {
-            assert!(object.map(name).is_some(), "map {name} missing");
+            assert!(map_by_name(&object, name).is_some(), "map {name} missing");
         }
     }
 
@@ -1067,7 +1065,9 @@ mod root_integration {
 /// here instead of silently breaking every policy lookup.
 #[cfg(test)]
 mod btf_contract {
+    use super::map_by_name;
     use bpfjailer_common::codec;
+    use libbpf_rs::MapCore as _;
 
     fn object_path() -> Option<std::path::PathBuf> {
         let root = std::env::var("CARGO_MANIFEST_DIR")
@@ -1084,7 +1084,8 @@ mod btf_contract {
         let btf = libbpf_rs::btf::Btf::from_path(object_path()?).ok()?;
         let s: libbpf_rs::btf::types::Struct<'_> = btf.type_by_name(struct_name)?;
         for m in s.iter() {
-            if m.name?.to_str().ok()? == member {
+            // 0.26 exposes member names as OsStr rather than CStr.
+            if m.name? == std::ffi::OsStr::new(member) {
                 return match m.attr {
                     libbpf_rs::btf::types::MemberAttr::Normal { offset } => Some(offset / 8),
                     _ => None,
@@ -1237,7 +1238,7 @@ mod btf_contract {
             ("domain_rules", 16, 1),
         ];
         for (name, key, value) in cases {
-            let map = object.map(name).expect("map present");
+            let map = map_by_name(&object, name).expect("map present");
             assert_eq!(map.key_size() as usize, key, "{name} key size");
             assert_eq!(map.value_size() as usize, value, "{name} value size");
         }

--- a/test_task_storage/Cargo.lock
+++ b/test_task_storage/Cargo.lock
@@ -68,18 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,38 +125,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -197,48 +157,37 @@ checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libbpf-rs"
-version = "0.21.2"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70f003d6e48e60a7ed55d4fb5b2419b91a962c903fa0b00e8db95a3b6651abc"
+checksum = "fd8e8db46a2d5967b5b3dba7aba32a875dc38f222395040607045635ec1f9b63"
 dependencies = [
- "bitflags 1.3.2",
- "lazy_static",
+ "bitflags",
  "libbpf-sys",
  "libc",
- "nix 0.26.4",
- "num_enum",
- "strum_macros",
- "thiserror",
  "vsprintf",
 ]
 
 [[package]]
 name = "libbpf-sys"
-version = "1.6.2+v1.6.2"
+version = "1.7.0+v1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0346fc595fa2c8e274903e8a0e3ed5e6a29183af167567f6289fd3b116881b"
+checksum = "a109478760b2900aa2a6f2087e9d0de1d9c535b1758602af2845d5d2ccfaed7c"
 dependencies = [
  "cc",
- "nix 0.30.1",
+ "nix",
  "pkg-config",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "log"
@@ -253,64 +202,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
 ]
-
-[[package]]
-name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -337,16 +238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit",
 ]
 
 [[package]]
@@ -397,12 +288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,7 +304,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -427,30 +312,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -470,45 +331,7 @@ dependencies = [
  "anyhow",
  "env_logger",
  "libbpf-rs",
- "libbpf-sys",
  "log",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -546,13 +369,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
 ]

--- a/test_task_storage/Cargo.toml
+++ b/test_task_storage/Cargo.toml
@@ -13,7 +13,7 @@ name = "test-task-storage"
 path = "src/main.rs"
 
 [dependencies]
-libbpf-rs = "0.21"
+libbpf-rs = "0.26"
 anyhow = "1.0"
 log = "0.4"
 env_logger = "0.11"

--- a/test_task_storage/src/main.rs
+++ b/test_task_storage/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use libbpf_rs::{ObjectBuilder};
+use libbpf_rs::{MapCore as _, ObjectBuilder};
+use std::ffi::OsStr;
 use log::{error, info};
 use std::path::PathBuf;
 
@@ -31,14 +32,14 @@ fn main() -> Result<()> {
             info!("✅ SUCCESS: task_storage map created successfully!");
 
             // Check if map exists
-            if object.map("test_task_storage").is_some() {
+            if object.maps().any(|m| m.name() == OsStr::new("test_task_storage")) {
                 info!("✅ Map 'test_task_storage' found in object");
             } else {
                 error!("❌ Map 'test_task_storage' not found in object");
             }
 
             // Check if program exists
-            if object.prog("test_task_alloc").is_some() {
+            if object.progs().any(|p| p.name() == OsStr::new("test_task_alloc")) {
                 info!("✅ Program 'test_task_alloc' found in object");
             } else {
                 error!("❌ Program 'test_task_alloc' not found in object");


### PR DESCRIPTION
Does the migration that #18 skipped.

#27 has since merged, so this now targets `main` directly and contains only the migration commit.

## Background

#18 ("Bump libbpf-rs from 0.21.2 to 0.26.1") changed four manifest files and
**not one line of Rust**. `main` stopped compiling with 47 `E0599` errors and
#22 pinned it back to `0.21`. So the version was migrated; the API never was.

## What 0.26 actually changes

**Name-based lookup on `Object` is gone.** `Object::map`, `map_mut`, `prog` and
`prog_mut` are replaced by iterating `maps()` / `maps_mut()` / `progs()` /
`progs_mut()`. Rather than open-code `.find(|m| m.name() == …)` at ~30 call
sites, each crate gets a small `map_by_name` / `prog_by_name` helper — one line
changed per site, and the iteration detail lives in one place.

**`lookup`/`update`/`delete` moved onto the `MapCore` trait**, which now has to
be in scope. They take `&self`, so the immutable iterator suffices everywhere
except pinning, which genuinely needs `maps_mut()`.

**BTF member names are `OsStr`, not `CStr`** — the layout contract tests from
#26 compare against `OsStr::new` now.

**`open_file`/`load` kept their shape**, so `BpfJailerBpf`'s structure is
unchanged. The `Arc<Mutex<Object>>` I worried about did not need rethinking.

## Verification

This is what the tests from #26 were for.

- 152 tests pass (98 without root), all gates green
- The appliance still enforces on a 6.18 kernel with BPF LSM active: a denied
  path is blocked, an unrelated path allowed, an unenrolled binary unaffected

The BTF layout assertions are worth calling out — they read struct offsets from
the compiled object, so they would have caught the migration silently changing
how a key is built. They did not fire, which is the answer we wanted.

## Also

`test_task_storage` is excluded from the workspace and therefore not built by
CI. It broke on 0.26 too and is migrated here rather than left on 0.21, where
the next person to build it would hit exactly the breakage this PR is fixing.

The dependabot ignore on `libbpf-rs` majors stays. The next major will break the
same way, and the fix is a migration, not a bump.

## Follow-up this unblocks

0.26 exposes `Program::test_run`. That makes it possible to execute
`hash_component()` from a test and compare it against the Rust implementation —
the one gap the BTF assertions cannot close, since they never run any BPF code.
Worth doing separately.
