### PR TITLE
Apply policy through one shared walk, and make padded map-key lookups deterministic

### DIFF
--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -4,7 +4,7 @@
 //! After setup, exits immediately. Programs remain active until reboot.
 
 use anyhow::{Context, Result};
-use bpfjailer_common::apply::{apply_role, PolicySink};
+use bpfjailer_common::apply::{apply_role, PolicySink, SystemResolver};
 use bpfjailer_common::codec;
 use bpfjailer_common::policy::PolicyConfig;
 use libbpf_rs::MapCore;
@@ -248,6 +248,20 @@ impl PolicySink for ObjectSink<'_> {
         Ok(())
     }
 
+    fn cache_resolved_ip(
+        &mut self,
+        role_id: u32,
+        ip: std::net::Ipv4Addr,
+        domain_hash: u64,
+    ) -> Result<()> {
+        self.map("dns_cache")?.update(
+            &codec::dns_cache_key(role_id, ip),
+            &codec::dns_cache_value(domain_hash, 0),
+            MapFlags::empty(),
+        )?;
+        Ok(())
+    }
+
     fn set_proxy(&mut self, role_id: u32, address: &str, required: bool) -> Result<()> {
         let (ip, port) = codec::parse_proxy_addr(address).map_err(|e| anyhow::anyhow!(e))?;
         self.map("proxy_config")?.update(
@@ -268,7 +282,7 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
     // domain_rules and proxy entirely.
     for (name, role) in &policy.roles {
         let mut sink = ObjectSink { object };
-        let skipped = apply_role(&mut sink, role)?;
+        let skipped = apply_role(&mut sink, role, &SystemResolver)?;
         for s in skipped {
             log::warn!("Role '{}': skipped {}", name, s);
         }

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -4,6 +4,8 @@
 //! After setup, exits immediately. Programs remain active until reboot.
 
 use anyhow::{Context, Result};
+use bpfjailer_common::apply::{apply_role, PolicySink};
+use bpfjailer_common::codec;
 use bpfjailer_common::policy::PolicyConfig;
 use libbpf_rs::MapCore;
 use libbpf_rs::{Link, MapFlags, Object, ObjectBuilder};
@@ -180,60 +182,97 @@ fn load_bpf_object() -> Result<(Object, Vec<Link>)> {
     Ok((object, links))
 }
 
+/// Writes role rules straight into the loaded object's maps.
+///
+/// The bootstrap has no daemon abstractions, so this is the thinnest possible
+/// adapter between [`apply_role`] and the raw maps.
+struct ObjectSink<'a> {
+    object: &'a Object,
+}
+
+impl ObjectSink<'_> {
+    fn map(&self, name: &str) -> Result<libbpf_rs::Map<'_>> {
+        map_by_name(self.object, name).ok_or_else(|| anyhow::anyhow!("{name} map not found"))
+    }
+}
+
+impl PolicySink for ObjectSink<'_> {
+    type Err = anyhow::Error;
+
+    fn set_role_flags(&mut self, role_id: u32, flags: u8) -> Result<()> {
+        self.map("role_flags")?
+            .update(&role_id.to_ne_bytes(), &[flags], MapFlags::empty())?;
+        Ok(())
+    }
+
+    fn add_path_state(&mut self, role_id: u32, pattern: &str, allow: bool) -> Result<()> {
+        let map = self.map("path_states")?;
+        for (key, value) in codec::path_state_entries(role_id, pattern, allow) {
+            map.update(&key, &value, MapFlags::empty())?;
+        }
+        Ok(())
+    }
+
+    fn add_network_rule(
+        &mut self,
+        role_id: u32,
+        port: u16,
+        protocol: u8,
+        direction: u8,
+        allow: bool,
+    ) -> Result<()> {
+        self.map("network_rules")?.update(
+            &codec::net_rule_key(role_id, port, protocol, direction),
+            &[allow as u8],
+            MapFlags::empty(),
+        )?;
+        Ok(())
+    }
+
+    fn add_ip_rule(&mut self, role_id: u32, cidr: &str, direction: u8, allow: bool) -> Result<()> {
+        let (ip, prefix_len) = codec::parse_cidr(cidr).map_err(|e| anyhow::anyhow!(e))?;
+        self.map("ip_rules")?.update(
+            &codec::ip_rule_key(role_id, ip, prefix_len, direction),
+            &[allow as u8],
+            MapFlags::empty(),
+        )?;
+        Ok(())
+    }
+
+    fn add_domain_rule(&mut self, role_id: u32, domain: &str, allow: bool) -> Result<()> {
+        self.map("domain_rules")?.update(
+            &codec::domain_rule_key(role_id, domain),
+            &[allow as u8],
+            MapFlags::empty(),
+        )?;
+        Ok(())
+    }
+
+    fn set_proxy(&mut self, role_id: u32, address: &str, required: bool) -> Result<()> {
+        let (ip, port) = codec::parse_proxy_addr(address).map_err(|e| anyhow::anyhow!(e))?;
+        self.map("proxy_config")?.update(
+            &role_id.to_ne_bytes(),
+            &codec::proxy_config_value(ip, port, required),
+            MapFlags::empty(),
+        )?;
+        Ok(())
+    }
+}
+
 fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
     log::info!("Populating BPF maps from policy...");
 
-    // Load roles and their flags
+    // Roles are applied through the shared walk in bpfjailer_common::apply, so
+    // the daemon and this bootstrap cannot diverge on which sections they
+    // honour. They previously did: this path silently ignored ip_rules,
+    // domain_rules and proxy entirely.
     for (name, role) in &policy.roles {
-        let role_id = role.id.0;
-        let flags = bpfjailer_common::flags::policy_flags_to_u8(&role.flags);
-
-        // Update role_flags map
-        if let Some(map) = map_by_name(object, "role_flags") {
-            let key = role_id.to_ne_bytes();
-            let value = [flags];
-            map.update(&key, &value, MapFlags::empty())?;
-            log::info!("Role '{}' (id={}) flags={:#x}", name, role_id, flags);
+        let mut sink = ObjectSink { object };
+        let skipped = apply_role(&mut sink, role)?;
+        for s in skipped {
+            log::warn!("Role '{}': skipped {}", name, s);
         }
-
-        // Load network rules
-        if let Some(map) = map_by_name(object, "network_rules") {
-            for rule in &role.network_rules {
-                let protocol = match rule.protocol.as_str() {
-                    "tcp" | "TCP" => 6u8,
-                    "udp" | "UDP" => 17u8,
-                    _ => continue,
-                };
-
-                let ports: Vec<u16> = if let Some(port) = rule.port {
-                    vec![port]
-                } else if let (Some(start), Some(end)) = (rule.port_start, rule.port_end) {
-                    (start..=end).collect()
-                } else {
-                    continue;
-                };
-
-                for port in ports {
-                    // Add both bind and connect rules
-                    for direction in [0u8, 1u8] {
-                        let mut key = [0u8; 8];
-                        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-                        key[4..6].copy_from_slice(&port.to_ne_bytes());
-                        key[6] = protocol;
-                        key[7] = direction;
-                        let value = [if rule.allow { 1u8 } else { 0u8 }];
-                        map.update(&key, &value, MapFlags::empty())?;
-                    }
-                }
-            }
-        }
-
-        // Load path rules (state machine)
-        if let Some(map) = map_by_name(object, "path_states") {
-            for path_rule in &role.file_paths {
-                add_path_state(&map, role_id, &path_rule.pattern, path_rule.allow)?;
-            }
-        }
+        log::info!("Role '{}' (id={}) applied", name, role.id.0);
     }
 
     // Load pod mappings
@@ -303,15 +342,6 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
     }
 
     log::info!("BPF maps populated");
-    Ok(())
-}
-
-fn add_path_state(map: &libbpf_rs::Map, role_id: u32, pattern: &str, allowed: bool) -> Result<()> {
-    // Shared with the daemon: both sides must produce byte-identical keys, so
-    // the walk lives in bpfjailer_common::codec rather than being duplicated.
-    for (key, value) in bpfjailer_common::codec::path_state_entries(role_id, pattern, allowed) {
-        map.update(&key, &value, MapFlags::empty())?;
-    }
     Ok(())
 }
 
@@ -556,12 +586,13 @@ mod root_integration {
 
     #[test]
     #[ignore = "requires root"]
-    fn add_path_state_matches_the_shared_codec() {
+    fn object_sink_writes_path_states_matching_the_codec() {
         let Some(object) = loaded_object() else {
             return;
         };
+        let mut sink = ObjectSink { object: &object };
+        sink.add_path_state(31, "/srv/data/", false).expect("add");
         let map = map_by_name(&object, "path_states").expect("map");
-        add_path_state(&map, 31, "/srv/data/", false).expect("add");
         for (key, value) in bpfjailer_common::codec::path_state_entries(31, "/srv/data/", false) {
             let got = map
                 .lookup(&key, MapFlags::empty())

--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -380,7 +380,6 @@ fn pin_all(object: &mut Object, links: &mut [Link]) -> Result<()> {
         "role_flags",
         "pending_enrollments",
         "network_rules",
-        "path_rules",
         "path_states",
         "inode_cache",
         "cache_generation",

--- a/bpfjailer-bpf/src/main.bpf.c
+++ b/bpfjailer-bpf/src/main.bpf.c
@@ -224,7 +224,10 @@ struct {
     __type(value, u8);
 } domain_rules SEC(".maps");
 
-// DNS cache: maps resolved IP -> domain hash (populated by DNS interception)
+// Resolved-address table: maps a resolved IP -> the hash of the name it came
+// from. Populated at policy load, not by DNS interception, so entries must
+// survive for the lifetime of the policy: a plain HASH, never an LRU_HASH.
+// An LRU here silently evicts policy state and the domain rule stops biting.
 struct dns_cache_key {
     u32 role_id;
     u32 ip_addr;      // Resolved IP address
@@ -236,7 +239,7 @@ struct dns_cache_value {
 };
 
 struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 8192);
     __type(key, struct dns_cache_key);
     __type(value, struct dns_cache_value);
@@ -405,11 +408,14 @@ static __always_inline int check_path_state_machine(u32 role_id, struct path_com
         return 0;  // No rule
 
     u32 state = PATH_STATE_ROOT;
-    struct path_state_key key = {
-        .role_id = role_id,
-        .state = 0,
-        .component_hash = 0,
-    };
+    // Zeroed explicitly: the struct has 4 bytes of padding before .state, and
+    // a BPF hash lookup compares the whole key. An initializer list leaves that
+    // padding as whatever the stack held, so lookups match only by luck.
+    struct path_state_key key;
+    __builtin_memset(&key, 0, sizeof(key));
+    key.role_id = role_id;
+    key.state = 0;
+    key.component_hash = 0;
 
     u8 count = buf->count;
     if (count > MAX_COMPONENTS)
@@ -549,10 +555,11 @@ int BPF_PROG(file_open, struct file *file)
         struct inode *inode = BPF_CORE_READ(dentry, d_inode);
 
         if (inode) {
-            struct inode_cache_key cache_key = {
-                .role_id = info->role_id,
-                .inode = (u64)inode,
-            };
+            // Zeroed explicitly: padded key, see path_state_key above.
+            struct inode_cache_key cache_key;
+            __builtin_memset(&cache_key, 0, sizeof(cache_key));
+            cache_key.role_id = info->role_id;
+            cache_key.inode = (u64)inode;
             struct inode_cache_value *cached = bpf_map_lookup_elem(&inode_cache, &cache_key);
             if (cached && cached->generation == current_gen) {
                 // Cache hit with valid generation
@@ -577,10 +584,11 @@ int BPF_PROG(file_open, struct file *file)
             if (result != 0) {
                 // Cache the decision with current generation
                 if (inode) {
-                    struct inode_cache_key cache_key = {
-                        .role_id = info->role_id,
-                        .inode = (u64)inode,
-                    };
+                    // Zeroed explicitly: padded key, see path_state_key above.
+                    struct inode_cache_key cache_key;
+                    __builtin_memset(&cache_key, 0, sizeof(cache_key));
+                    cache_key.role_id = info->role_id;
+                    cache_key.inode = (u64)inode;
                     struct inode_cache_value val = {
                         .decision = (result == 1) ? 1 : 0,
                         .generation = current_gen,
@@ -703,6 +711,46 @@ static __always_inline int is_proxy_connection(u32 role_id, u32 ip_addr, u16 por
 
 // Check proxy enforcement
 // Returns: 0 = allowed, -13 = blocked (not going through proxy)
+// Resolve a destination IP back to the domain it was resolved from, then
+// consult that role's domain rules.
+//
+// dns_cache is populated by userspace: at policy load each domain in a role's
+// domain_rules is resolved and every returned address recorded. BPF cannot
+// parse DNS itself -- the verifier will not accept it -- so this is name
+// filtering approximated by address, with the limits that implies:
+//
+//   * an address that changes after load is not covered until the next refresh
+//   * a host serving several names shares one entry, last writer wins
+//   * a process that resolves a name itself and connects to some other address
+//     is not caught, because nothing here observes the resolution
+//
+// Returns 1 to allow, -13 to deny, 0 when the address is unknown to us and the
+// decision belongs to the rules that follow.
+static __always_inline int check_domain_access(u32 role_id, u32 ip_addr)
+{
+    if (ip_addr == 0)
+        return 0;
+
+    struct dns_cache_key ck = {
+        .role_id = role_id,
+        .ip_addr = ip_addr,
+    };
+    struct dns_cache_value *cached = bpf_map_lookup_elem(&dns_cache, &ck);
+    if (!cached)
+        return 0;  // address not associated with any name we were told about
+
+    // Zeroed explicitly: padded key, see path_state_key above.
+    struct domain_rule_key dk;
+    __builtin_memset(&dk, 0, sizeof(dk));
+    dk.role_id = role_id;
+    dk.domain_hash = cached->domain_hash;
+    u8 *allow = bpf_map_lookup_elem(&domain_rules, &dk);
+    if (!allow)
+        return 0;  // name known, but this role has no rule for it
+
+    return *allow ? 1 : -13;
+}
+
 static __always_inline int check_proxy_requirement(u32 role_id, u32 ip_addr, u16 port)
 {
     struct proxy_config *config = bpf_map_lookup_elem(&proxy_config, &role_id);
@@ -868,7 +916,6 @@ int BPF_PROG(socket_connect, struct socket *sock, struct sockaddr *address, int 
         bpf_probe_read_kernel(&be_port, sizeof(be_port), &addr6->sin6_port);
         dest_port = bpf_ntohs(be_port);
     }
-
     // Check proxy requirement first (if configured)
     if (dest_ip != 0) {
         int proxy_result = check_proxy_requirement(info->role_id, dest_ip, dest_port);
@@ -876,6 +923,20 @@ int BPF_PROG(socket_connect, struct socket *sock, struct sockaddr *address, int 
             emit_audit_event(ctx, pid, info->role_id, info->pod_id,
                              AUDIT_DECISION_DENY, AUDIT_HOOK_SOCKET_CONNECT, dest_ip);
             return -13;  // Blocked: not going through required proxy
+        }
+    }
+
+    // Check domain rules first: they are the most specific statement of intent
+    // the operator can make about an egress destination.
+    if (dest_ip != 0) {
+        int domain_result = check_domain_access(info->role_id, dest_ip);
+        if (domain_result == -13) {
+            emit_audit_event(ctx, pid, info->role_id, info->pod_id,
+                             AUDIT_DECISION_DENY, AUDIT_HOOK_SOCKET_CONNECT, dest_ip);
+            return -13;
+        }
+        if (domain_result == 1) {
+            return 0;
         }
     }
 
@@ -1135,8 +1196,9 @@ int BPF_PROG(bpf, int cmd, union bpf_attr *attr, unsigned int size)
 // =============================================================================
 // DNS Interception for Domain-based Filtering (Simplified)
 // =============================================================================
-// Note: Full DNS parsing is too complex for BPF verifier.
-// Domain filtering is handled at IP level via dns_cache populated by userspace.
+// Note: Full DNS parsing is too complex for BPF verifier, so domain
+// filtering is done at IP level in check_domain_access() above, against a
+// dns_cache that userspace populates by resolving each policy domain.
 
 #define DNS_PORT 53
 #define AUDIT_HOOK_DNS_QUERY 6

--- a/bpfjailer-bpf/src/main.bpf.c
+++ b/bpfjailer-bpf/src/main.bpf.c
@@ -137,21 +137,6 @@ struct {
     __type(value, u32);
 } cache_generation SEC(".maps");
 
-// Legacy path_rules map (kept for compatibility)
-#define PATH_RULE_MAX_LEN 256
-
-struct path_rule_key {
-    u32 role_id;
-    u64 path_hash;
-};
-
-struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, 8192);
-    __type(key, struct path_rule_key);
-    __type(value, u8);
-} path_rules SEC(".maps");
-
 // Auto-enrollment by executable inode
 struct exec_enrollment_value {
     u64 pod_id;
@@ -407,7 +392,15 @@ static __always_inline int check_path_state_machine(u32 role_id, struct path_com
     if (buf->count == 0)
         return 0;  // No rule
 
-    u32 state = PATH_STATE_ROOT;
+    // Width is taken from the map key rather than spelled out, and asserted
+    // below: a u32 here silently truncated the u64 next_state, so every
+    // pattern with more than one component missed on its second lookup and
+    // the walk fell through to the role's default.
+    typeof(((struct path_state_key *)0)->state) state = PATH_STATE_ROOT;
+    _Static_assert(sizeof(state) == sizeof(((struct path_state_key *)0)->state),
+                   "path walk state must be exactly as wide as path_state_key.state");
+    _Static_assert(sizeof(state) == sizeof(((struct path_state_value *)0)->next_state),
+                   "path walk state must be exactly as wide as path_state_value.next_state");
     // Zeroed explicitly: the struct has 4 bytes of padding before .state, and
     // a BPF hash lookup compares the whole key. An initializer list leaves that
     // padding as whatever the stack held, so lookups match only by luck.

--- a/bpfjailer-common/src/apply.rs
+++ b/bpfjailer-common/src/apply.rs
@@ -1,0 +1,293 @@
+//! One place that turns a [`Role`] into map writes.
+//!
+//! The daemon and the daemonless bootstrap previously each walked a `Role` and
+//! decided what to apply. They drifted three times: the daemon packed only
+//! three of eight flag bits, both carried their own copy of the path-pattern
+//! walk, and the bootstrap silently ignored `ip_rules`, `domain_rules` and
+//! `proxy` entirely -- a policy asking for them was applied as if those
+//! sections were not there.
+//!
+//! [`apply_role`] is the single walk. Anything that can write BPF maps
+//! implements [`PolicySink`], and adding a field to `Role` means adding it
+//! here once, where `apply_role_covers_every_enforcing_field` will
+//! notice if it is skipped.
+
+use crate::flags::policy_flags_to_u8;
+use crate::policy::Role;
+
+/// Somewhere role rules can be written. Implemented over the daemon's BPF
+/// handle and over the bootstrap's raw object.
+///
+/// Methods take plain data rather than map handles so this crate stays free of
+/// libbpf.
+pub trait PolicySink {
+    type Err;
+
+    fn set_role_flags(&mut self, role_id: u32, flags: u8) -> Result<(), Self::Err>;
+    fn add_path_state(&mut self, role_id: u32, pattern: &str, allow: bool)
+        -> Result<(), Self::Err>;
+    fn add_network_rule(
+        &mut self,
+        role_id: u32,
+        port: u16,
+        protocol: u8,
+        direction: u8,
+        allow: bool,
+    ) -> Result<(), Self::Err>;
+    fn add_ip_rule(
+        &mut self,
+        role_id: u32,
+        cidr: &str,
+        direction: u8,
+        allow: bool,
+    ) -> Result<(), Self::Err>;
+    fn add_domain_rule(&mut self, role_id: u32, domain: &str, allow: bool)
+        -> Result<(), Self::Err>;
+    fn set_proxy(&mut self, role_id: u32, address: &str, required: bool) -> Result<(), Self::Err>;
+}
+
+/// Directions a rule is written for: 0 = bind, 1 = connect.
+const BIND: u8 = 0;
+const CONNECT: u8 = 1;
+
+/// Apply every enforcing section of a role.
+///
+/// Unusable rules are skipped rather than aborting the role -- an unknown
+/// protocol or an inverted port range should not stop the rest of the policy
+/// being applied -- but the caller is told via the returned skip list so it can
+/// log rather than swallow them.
+pub fn apply_role<S: PolicySink>(sink: &mut S, role: &Role) -> Result<Vec<String>, S::Err> {
+    let role_id = role.id.0;
+    let mut skipped = Vec::new();
+
+    sink.set_role_flags(role_id, policy_flags_to_u8(&role.flags))?;
+
+    for p in &role.file_paths {
+        sink.add_path_state(role_id, &p.pattern, p.allow)?;
+    }
+
+    for r in &role.network_rules {
+        match crate::codec::expand_network_rule(&r.protocol, r.port, r.port_start, r.port_end) {
+            Some((protocol, ports)) => {
+                for port in ports {
+                    sink.add_network_rule(role_id, port, protocol, BIND, r.allow)?;
+                    sink.add_network_rule(role_id, port, protocol, CONNECT, r.allow)?;
+                }
+            }
+            None => skipped.push(format!("network rule for protocol {:?}", r.protocol)),
+        }
+    }
+
+    for r in &role.ip_rules {
+        let direction = match r.direction.as_str() {
+            "bind" => BIND,
+            "connect" => CONNECT,
+            other => {
+                skipped.push(format!("ip rule {} with direction {other:?}", r.cidr));
+                continue;
+            }
+        };
+        sink.add_ip_rule(role_id, &r.cidr, direction, r.allow)?;
+    }
+
+    for r in &role.domain_rules {
+        sink.add_domain_rule(role_id, &r.domain, r.allow)?;
+    }
+
+    if let Some(p) = &role.proxy {
+        sink.set_proxy(role_id, &p.address, p.required)?;
+    }
+
+    Ok(skipped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::{DomainRule, IpRule, NetworkRule, PathPattern, ProxyConfig};
+    use crate::types::{PolicyFlags, RoleId};
+
+    #[derive(Default)]
+    struct Recorder {
+        flags: Vec<(u32, u8)>,
+        paths: Vec<(u32, String, bool)>,
+        net: Vec<(u32, u16, u8, u8, bool)>,
+        ip: Vec<(u32, String, u8, bool)>,
+        domain: Vec<(u32, String, bool)>,
+        proxy: Vec<(u32, String, bool)>,
+    }
+
+    impl PolicySink for Recorder {
+        type Err = std::convert::Infallible;
+        fn set_role_flags(&mut self, r: u32, f: u8) -> Result<(), Self::Err> {
+            self.flags.push((r, f));
+            Ok(())
+        }
+        fn add_path_state(&mut self, r: u32, p: &str, a: bool) -> Result<(), Self::Err> {
+            self.paths.push((r, p.into(), a));
+            Ok(())
+        }
+        fn add_network_rule(
+            &mut self,
+            r: u32,
+            port: u16,
+            proto: u8,
+            dir: u8,
+            a: bool,
+        ) -> Result<(), Self::Err> {
+            self.net.push((r, port, proto, dir, a));
+            Ok(())
+        }
+        fn add_ip_rule(&mut self, r: u32, c: &str, d: u8, a: bool) -> Result<(), Self::Err> {
+            self.ip.push((r, c.into(), d, a));
+            Ok(())
+        }
+        fn add_domain_rule(&mut self, r: u32, d: &str, a: bool) -> Result<(), Self::Err> {
+            self.domain.push((r, d.into(), a));
+            Ok(())
+        }
+        fn set_proxy(&mut self, r: u32, addr: &str, req: bool) -> Result<(), Self::Err> {
+            self.proxy.push((r, addr.into(), req));
+            Ok(())
+        }
+    }
+
+    /// A role exercising every enforcing section.
+    fn full_role() -> Role {
+        Role {
+            id: RoleId(7),
+            name: "full".into(),
+            flags: PolicyFlags {
+                allow_file_access: true,
+                allow_network: true,
+                allow_exec: true,
+                require_signed_binary: false,
+                allow_setuid: true,
+                allow_ptrace: true,
+                allow_module_load: true,
+                allow_bpf_load: true,
+                require_proxy: false,
+            },
+            file_paths: vec![PathPattern {
+                pattern: "/etc/shadow".into(),
+                allow: false,
+            }],
+            network_rules: vec![NetworkRule {
+                protocol: "tcp".into(),
+                address: None,
+                port: Some(443),
+                port_start: None,
+                port_end: None,
+                allow: true,
+            }],
+            execution_rules: vec![],
+            require_signed_binary: false,
+            ip_rules: vec![IpRule {
+                cidr: "10.0.0.0/8".into(),
+                direction: "connect".into(),
+                allow: false,
+            }],
+            domain_rules: vec![DomainRule {
+                domain: "api.example.com".into(),
+                allow: true,
+            }],
+            proxy: Some(ProxyConfig {
+                address: "127.0.0.1:3128".into(),
+                required: true,
+            }),
+        }
+    }
+
+    /// The regression that motivated this module: the bootstrap applied flags,
+    /// paths and network rules but silently dropped ip_rules, domain_rules and
+    /// proxy. Every enforcing section must reach the sink.
+    #[test]
+    fn apply_role_covers_every_enforcing_field() {
+        let mut rec = Recorder::default();
+        let skipped = apply_role(&mut rec, &full_role()).unwrap();
+        assert!(skipped.is_empty(), "nothing should be skipped: {skipped:?}");
+
+        assert_eq!(rec.flags.len(), 1, "flags not applied");
+        assert_eq!(rec.paths.len(), 1, "file_paths not applied");
+        assert!(!rec.net.is_empty(), "network_rules not applied");
+        assert_eq!(rec.ip.len(), 1, "ip_rules not applied");
+        assert_eq!(rec.domain.len(), 1, "domain_rules not applied");
+        assert_eq!(rec.proxy.len(), 1, "proxy not applied");
+    }
+
+    #[test]
+    fn network_rules_are_written_for_both_directions() {
+        let mut rec = Recorder::default();
+        apply_role(&mut rec, &full_role()).unwrap();
+        let dirs: Vec<u8> = rec.net.iter().map(|n| n.3).collect();
+        assert!(dirs.contains(&BIND) && dirs.contains(&CONNECT));
+    }
+
+    #[test]
+    fn ip_rule_direction_is_translated() {
+        let mut role = full_role();
+        role.ip_rules[0].direction = "bind".into();
+        let mut rec = Recorder::default();
+        apply_role(&mut rec, &role).unwrap();
+        assert_eq!(rec.ip[0].2, BIND);
+    }
+
+    #[test]
+    fn an_unknown_ip_direction_is_reported_not_applied() {
+        let mut role = full_role();
+        role.ip_rules[0].direction = "sideways".into();
+        let mut rec = Recorder::default();
+        let skipped = apply_role(&mut rec, &role).unwrap();
+        assert!(rec.ip.is_empty(), "must not guess a direction");
+        assert_eq!(skipped.len(), 1);
+        assert!(skipped[0].contains("sideways"), "{skipped:?}");
+    }
+
+    #[test]
+    fn an_unusable_network_rule_is_reported_and_the_rest_still_applies() {
+        let mut role = full_role();
+        role.network_rules.insert(
+            0,
+            NetworkRule {
+                protocol: "icmp".into(),
+                address: None,
+                port: Some(0),
+                port_start: None,
+                port_end: None,
+                allow: true,
+            },
+        );
+        let mut rec = Recorder::default();
+        let skipped = apply_role(&mut rec, &role).unwrap();
+        assert_eq!(skipped.len(), 1, "the icmp rule should be reported");
+        assert!(!rec.net.is_empty(), "the tcp rule must still be applied");
+        assert_eq!(rec.proxy.len(), 1, "later sections must still be applied");
+    }
+
+    #[test]
+    fn a_role_with_no_optional_sections_applies_only_flags() {
+        let mut role = full_role();
+        role.file_paths.clear();
+        role.network_rules.clear();
+        role.ip_rules.clear();
+        role.domain_rules.clear();
+        role.proxy = None;
+        let mut rec = Recorder::default();
+        apply_role(&mut rec, &role).unwrap();
+        assert_eq!(rec.flags.len(), 1);
+        assert!(rec.paths.is_empty() && rec.net.is_empty() && rec.ip.is_empty());
+        assert!(rec.domain.is_empty() && rec.proxy.is_empty());
+    }
+
+    #[test]
+    fn every_write_carries_the_roles_own_id() {
+        let mut rec = Recorder::default();
+        apply_role(&mut rec, &full_role()).unwrap();
+        assert!(rec.flags.iter().all(|x| x.0 == 7));
+        assert!(rec.paths.iter().all(|x| x.0 == 7));
+        assert!(rec.net.iter().all(|x| x.0 == 7));
+        assert!(rec.ip.iter().all(|x| x.0 == 7));
+        assert!(rec.domain.iter().all(|x| x.0 == 7));
+        assert!(rec.proxy.iter().all(|x| x.0 == 7));
+    }
+}

--- a/bpfjailer-common/src/apply.rs
+++ b/bpfjailer-common/src/apply.rs
@@ -14,6 +14,36 @@
 
 use crate::flags::policy_flags_to_u8;
 use crate::policy::Role;
+use std::net::Ipv4Addr;
+
+/// Turns a policy domain into the addresses it currently resolves to.
+///
+/// Injected so [`apply_role`] stays testable without touching the network, and
+/// so both modes resolve identically.
+pub trait DomainResolver {
+    fn resolve(&self, domain: &str) -> Vec<Ipv4Addr>;
+}
+
+/// Resolves through the system resolver.
+pub struct SystemResolver;
+
+impl DomainResolver for SystemResolver {
+    fn resolve(&self, domain: &str) -> Vec<Ipv4Addr> {
+        use std::net::ToSocketAddrs;
+        // Port is irrelevant; ToSocketAddrs just needs one to parse.
+        match (domain, 0u16).to_socket_addrs() {
+            Ok(addrs) => addrs
+                .filter_map(|a| match a.ip() {
+                    std::net::IpAddr::V4(v4) => Some(v4),
+                    // BPF matches on IPv4 only, so v6 answers are dropped
+                    // rather than silently treated as covered.
+                    std::net::IpAddr::V6(_) => None,
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+}
 
 /// Somewhere role rules can be written. Implemented over the daemon's BPF
 /// handle and over the bootstrap's raw object.
@@ -44,6 +74,14 @@ pub trait PolicySink {
     fn add_domain_rule(&mut self, role_id: u32, domain: &str, allow: bool)
         -> Result<(), Self::Err>;
     fn set_proxy(&mut self, role_id: u32, address: &str, required: bool) -> Result<(), Self::Err>;
+    /// Record that `ip` currently resolves to the domain hashed as
+    /// `domain_hash`, so BPF can map a connect target back to a name.
+    fn cache_resolved_ip(
+        &mut self,
+        role_id: u32,
+        ip: Ipv4Addr,
+        domain_hash: u64,
+    ) -> Result<(), Self::Err>;
 }
 
 /// Directions a rule is written for: 0 = bind, 1 = connect.
@@ -56,7 +94,11 @@ const CONNECT: u8 = 1;
 /// protocol or an inverted port range should not stop the rest of the policy
 /// being applied -- but the caller is told via the returned skip list so it can
 /// log rather than swallow them.
-pub fn apply_role<S: PolicySink>(sink: &mut S, role: &Role) -> Result<Vec<String>, S::Err> {
+pub fn apply_role<S: PolicySink, R: DomainResolver + ?Sized>(
+    sink: &mut S,
+    role: &Role,
+    resolver: &R,
+) -> Result<Vec<String>, S::Err> {
     let role_id = role.id.0;
     let mut skipped = Vec::new();
 
@@ -92,6 +134,21 @@ pub fn apply_role<S: PolicySink>(sink: &mut S, role: &Role) -> Result<Vec<String
 
     for r in &role.domain_rules {
         sink.add_domain_rule(role_id, &r.domain, r.allow)?;
+
+        // BPF matches a connect target by address, so the rule only bites for
+        // addresses we have associated with the name.
+        let addrs = resolver.resolve(&r.domain);
+        if addrs.is_empty() {
+            skipped.push(format!(
+                "domain rule {} (resolved to no IPv4 address, so it will not match)",
+                r.domain
+            ));
+            continue;
+        }
+        let hash = crate::hash::fnv1a_hash_u64(&r.domain);
+        for ip in addrs {
+            sink.cache_resolved_ip(role_id, ip, hash)?;
+        }
     }
 
     if let Some(p) = &role.proxy {
@@ -115,6 +172,21 @@ mod tests {
         ip: Vec<(u32, String, u8, bool)>,
         domain: Vec<(u32, String, bool)>,
         proxy: Vec<(u32, String, bool)>,
+        cached: Vec<(u32, Ipv4Addr, u64)>,
+    }
+
+    /// Resolves every name to a fixed address, so tests never touch DNS.
+    struct FakeResolver(Vec<Ipv4Addr>);
+    impl DomainResolver for FakeResolver {
+        fn resolve(&self, _domain: &str) -> Vec<Ipv4Addr> {
+            self.0.clone()
+        }
+    }
+    fn resolving() -> FakeResolver {
+        FakeResolver(vec!["93.184.216.34".parse().unwrap()])
+    }
+    fn resolving_nothing() -> FakeResolver {
+        FakeResolver(Vec::new())
     }
 
     impl PolicySink for Recorder {
@@ -148,6 +220,10 @@ mod tests {
         }
         fn set_proxy(&mut self, r: u32, addr: &str, req: bool) -> Result<(), Self::Err> {
             self.proxy.push((r, addr.into(), req));
+            Ok(())
+        }
+        fn cache_resolved_ip(&mut self, r: u32, ip: Ipv4Addr, h: u64) -> Result<(), Self::Err> {
+            self.cached.push((r, ip, h));
             Ok(())
         }
     }
@@ -204,7 +280,7 @@ mod tests {
     #[test]
     fn apply_role_covers_every_enforcing_field() {
         let mut rec = Recorder::default();
-        let skipped = apply_role(&mut rec, &full_role()).unwrap();
+        let skipped = apply_role(&mut rec, &full_role(), &resolving()).unwrap();
         assert!(skipped.is_empty(), "nothing should be skipped: {skipped:?}");
 
         assert_eq!(rec.flags.len(), 1, "flags not applied");
@@ -218,7 +294,7 @@ mod tests {
     #[test]
     fn network_rules_are_written_for_both_directions() {
         let mut rec = Recorder::default();
-        apply_role(&mut rec, &full_role()).unwrap();
+        apply_role(&mut rec, &full_role(), &resolving()).unwrap();
         let dirs: Vec<u8> = rec.net.iter().map(|n| n.3).collect();
         assert!(dirs.contains(&BIND) && dirs.contains(&CONNECT));
     }
@@ -228,7 +304,7 @@ mod tests {
         let mut role = full_role();
         role.ip_rules[0].direction = "bind".into();
         let mut rec = Recorder::default();
-        apply_role(&mut rec, &role).unwrap();
+        apply_role(&mut rec, &role, &resolving()).unwrap();
         assert_eq!(rec.ip[0].2, BIND);
     }
 
@@ -237,7 +313,7 @@ mod tests {
         let mut role = full_role();
         role.ip_rules[0].direction = "sideways".into();
         let mut rec = Recorder::default();
-        let skipped = apply_role(&mut rec, &role).unwrap();
+        let skipped = apply_role(&mut rec, &role, &resolving()).unwrap();
         assert!(rec.ip.is_empty(), "must not guess a direction");
         assert_eq!(skipped.len(), 1);
         assert!(skipped[0].contains("sideways"), "{skipped:?}");
@@ -258,7 +334,7 @@ mod tests {
             },
         );
         let mut rec = Recorder::default();
-        let skipped = apply_role(&mut rec, &role).unwrap();
+        let skipped = apply_role(&mut rec, &role, &resolving()).unwrap();
         assert_eq!(skipped.len(), 1, "the icmp rule should be reported");
         assert!(!rec.net.is_empty(), "the tcp rule must still be applied");
         assert_eq!(rec.proxy.len(), 1, "later sections must still be applied");
@@ -273,21 +349,61 @@ mod tests {
         role.domain_rules.clear();
         role.proxy = None;
         let mut rec = Recorder::default();
-        apply_role(&mut rec, &role).unwrap();
+        apply_role(&mut rec, &role, &resolving()).unwrap();
         assert_eq!(rec.flags.len(), 1);
         assert!(rec.paths.is_empty() && rec.net.is_empty() && rec.ip.is_empty());
         assert!(rec.domain.is_empty() && rec.proxy.is_empty());
     }
 
+    /// A domain rule only bites for addresses we have associated with the
+    /// name, so applying one must also populate the cache.
+    #[test]
+    fn domain_rules_populate_the_resolved_address_cache() {
+        let mut rec = Recorder::default();
+        apply_role(&mut rec, &full_role(), &resolving()).unwrap();
+        assert_eq!(rec.domain.len(), 1);
+        assert_eq!(rec.cached.len(), 1, "resolved address not cached");
+        let (role, ip, hash) = rec.cached[0];
+        assert_eq!(role, 7);
+        assert_eq!(ip, "93.184.216.34".parse::<Ipv4Addr>().unwrap());
+        assert_eq!(hash, crate::hash::fnv1a_hash_u64("api.example.com"));
+    }
+
+    #[test]
+    fn every_resolved_address_is_cached() {
+        let mut rec = Recorder::default();
+        let r = FakeResolver(vec!["1.1.1.1".parse().unwrap(), "1.0.0.1".parse().unwrap()]);
+        apply_role(&mut rec, &full_role(), &r).unwrap();
+        assert_eq!(
+            rec.cached.len(),
+            2,
+            "a name with several addresses needs all of them"
+        );
+    }
+
+    /// A name that resolves to nothing cannot match, so say so rather than
+    /// leaving the operator thinking the rule is in force.
+    #[test]
+    fn an_unresolvable_domain_is_reported() {
+        let mut rec = Recorder::default();
+        let skipped = apply_role(&mut rec, &full_role(), &resolving_nothing()).unwrap();
+        assert!(rec.cached.is_empty());
+        assert_eq!(skipped.len(), 1);
+        assert!(skipped[0].contains("api.example.com"), "{skipped:?}");
+        assert!(skipped[0].contains("will not match"), "{skipped:?}");
+        assert_eq!(rec.domain.len(), 1, "the rule itself is still written");
+    }
+
     #[test]
     fn every_write_carries_the_roles_own_id() {
         let mut rec = Recorder::default();
-        apply_role(&mut rec, &full_role()).unwrap();
+        apply_role(&mut rec, &full_role(), &resolving()).unwrap();
         assert!(rec.flags.iter().all(|x| x.0 == 7));
         assert!(rec.paths.iter().all(|x| x.0 == 7));
         assert!(rec.net.iter().all(|x| x.0 == 7));
         assert!(rec.ip.iter().all(|x| x.0 == 7));
         assert!(rec.domain.iter().all(|x| x.0 == 7));
         assert!(rec.proxy.iter().all(|x| x.0 == 7));
+        assert!(rec.cached.iter().all(|x| x.0 == 7));
     }
 }

--- a/bpfjailer-common/src/codec.rs
+++ b/bpfjailer-common/src/codec.rs
@@ -617,3 +617,183 @@ mod network_rule_tests {
         assert_eq!(ports, vec![80]);
     }
 }
+
+/// `struct dns_cache_key { u32 role_id; u32 ip_addr; }`
+///
+/// `ip_addr` is network byte order, matching `sin_addr.s_addr` as BPF reads it.
+pub fn dns_cache_key(role_id: u32, ip: Ipv4Addr) -> [u8; 8] {
+    let mut k = [0u8; 8];
+    k[0..4].copy_from_slice(&role_id.to_ne_bytes());
+    k[4..8].copy_from_slice(&ip.octets());
+    k
+}
+
+/// `struct dns_cache_value { u64 domain_hash; u64 timestamp; }`
+///
+/// `timestamp` is written but not yet consulted: nothing expires entries, so a
+/// stale address stays associated with its name until the next policy load.
+pub fn dns_cache_value(domain_hash: u64, timestamp: u64) -> [u8; 16] {
+    let mut v = [0u8; 16];
+    v[0..8].copy_from_slice(&domain_hash.to_ne_bytes());
+    v[8..16].copy_from_slice(&timestamp.to_ne_bytes());
+    v
+}
+
+#[cfg(test)]
+mod dns_cache_tests {
+    use super::*;
+
+    #[test]
+    fn dns_cache_key_layout() {
+        let k = dns_cache_key(9, "93.184.216.34".parse().unwrap());
+        assert_eq!(u32::from_ne_bytes(k[0..4].try_into().unwrap()), 9);
+        assert_eq!(&k[4..8], &[93, 184, 216, 34], "network byte order");
+    }
+
+    #[test]
+    fn dns_cache_value_layout() {
+        let v = dns_cache_value(0xAABB_CCDD_1122_3344, 42);
+        assert_eq!(
+            u64::from_ne_bytes(v[0..8].try_into().unwrap()),
+            0xAABB_CCDD_1122_3344
+        );
+        assert_eq!(u64::from_ne_bytes(v[8..16].try_into().unwrap()), 42);
+    }
+
+    #[test]
+    fn different_roles_do_not_share_a_cache_entry() {
+        let ip: Ipv4Addr = "1.2.3.4".parse().unwrap();
+        assert_ne!(dns_cache_key(1, ip), dns_cache_key(2, ip));
+    }
+}
+
+/// A BPF hash lookup compares the *whole* key, padding included. A key struct
+/// built with an initializer list leaves its padding as whatever the stack
+/// held, so such a lookup matches only when that happens to be zero.
+///
+/// This cost us a domain rule that enforced roughly one connect in three: the
+/// unpadded `dns_cache_key` hit every time while the padded `domain_rule_key`
+/// beside it missed at random. These tests fail if a padded key is ever
+/// initialized that way again.
+#[cfg(test)]
+mod bpf_key_padding {
+    const SRC: &str = include_str!("../../bpfjailer-bpf/src/main.bpf.c");
+
+    fn width(ty: &str) -> Option<usize> {
+        match ty {
+            "u8" | "s8" | "char" => Some(1),
+            "u16" | "s16" | "__be16" => Some(2),
+            "u32" | "s32" | "__be32" => Some(4),
+            "u64" | "s64" => Some(8),
+            _ => None,
+        }
+    }
+
+    /// Every `struct *key* { .. }` in the BPF source, paired with whether the
+    /// C layout rules insert padding into it.
+    fn key_structs() -> Vec<(String, bool)> {
+        let mut out = Vec::new();
+        for (idx, _) in SRC.match_indices("struct ") {
+            let rest = &SRC[idx + "struct ".len()..];
+            let Some(brace) = rest.find('{') else {
+                continue;
+            };
+            let name = rest[..brace].trim();
+            if !name.contains("key") || name.contains(char::is_whitespace) {
+                continue;
+            }
+            let Some(end) = rest.find('}') else { continue };
+            if end < brace {
+                continue;
+            }
+
+            // Strip trailing `//` comments first. Splitting on `;` while they
+            // are present pushes the *next* field into a segment that begins
+            // with the comment, and dropping that segment loses a real field.
+            let body: String = rest[brace + 1..end]
+                .lines()
+                .map(|l| l.split("//").next().unwrap_or(""))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let mut offset = 0usize;
+            let mut widest = 1usize;
+            let mut padded = false;
+            let mut parsed_all = true;
+            for field in body.split(';') {
+                let field = field.trim();
+                if field.is_empty() {
+                    continue;
+                }
+                let mut parts = field.split_whitespace();
+                let (Some(ty), Some(decl)) = (parts.next(), parts.next()) else {
+                    continue;
+                };
+                let Some(w) = width(ty) else {
+                    parsed_all = false;
+                    break;
+                };
+                // arrays: `u8 name[4]`
+                let count = decl
+                    .split_once('[')
+                    .and_then(|(_, n)| n.trim_end_matches(']').parse::<usize>().ok())
+                    .unwrap_or(1);
+                if !offset.is_multiple_of(w) {
+                    padded = true;
+                    offset += w - offset % w;
+                }
+                offset += w * count;
+                widest = widest.max(w);
+            }
+            if parsed_all {
+                if !offset.is_multiple_of(widest) {
+                    padded = true;
+                }
+                out.push((name.to_string(), padded));
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn the_source_still_contains_key_structs_to_check() {
+        let keys = key_structs();
+        assert!(
+            keys.len() >= 5,
+            "expected to parse several key structs, found {keys:?} -- the parser has \
+             probably drifted from the source and is silently checking nothing"
+        );
+        assert!(
+            keys.iter().any(|(_, padded)| *padded),
+            "expected at least one padded key; if the layouts genuinely changed so that \
+             none are padded, this guard can go, but verify that before deleting it"
+        );
+    }
+
+    #[test]
+    fn no_padded_key_is_built_with_an_initializer_list() {
+        let offenders: Vec<_> = key_structs()
+            .into_iter()
+            .filter(|(_, padded)| *padded)
+            .map(|(name, _)| name)
+            .filter(|name| SRC.contains(&format!("struct {name} ")))
+            .filter(|name| {
+                // `struct <name> <var> = {` anywhere means the padding is
+                // indeterminate. Zeroing via __builtin_memset is the fix.
+                SRC.match_indices(&format!("struct {name} ")).any(|(i, _)| {
+                    let tail = &SRC[i..];
+                    let line_end = tail.find('\n').unwrap_or(tail.len());
+                    tail[..line_end].contains("= {")
+                })
+            })
+            .collect();
+
+        assert!(
+            offenders.is_empty(),
+            "these padded key structs are built with an initializer list, so their \
+             padding is whatever the stack held and map lookups will match only \
+             intermittently: {offenders:?}. Declare them, __builtin_memset(&k, 0, \
+             sizeof(k)), then assign the fields."
+        );
+    }
+}

--- a/bpfjailer-common/src/codec.rs
+++ b/bpfjailer-common/src/codec.rs
@@ -117,14 +117,6 @@ pub fn net_rule_key(role_id: u32, port: u16, protocol: u8, direction: u8) -> [u8
     k
 }
 
-/// `struct path_rule_key { u32 role_id; u64 path_hash; }` (4 bytes padding)
-pub fn path_rule_key(role_id: u32, path: &str) -> [u8; 16] {
-    let mut k = [0u8; 16];
-    k[0..4].copy_from_slice(&role_id.to_ne_bytes());
-    k[8..16].copy_from_slice(&fnv1a_hash_u64(path).to_ne_bytes());
-    k
-}
-
 /// `struct domain_rule_key { u32 role_id; u64 domain_hash; }` (4 bytes padding)
 pub fn domain_rule_key(role_id: u32, domain: &str) -> [u8; 16] {
     let mut k = [0u8; 16];
@@ -370,13 +362,10 @@ mod tests {
     }
 
     #[test]
-    fn path_and_domain_rule_keys_pad_before_the_hash() {
-        let k = path_rule_key(5, "/etc/shadow");
-        assert_eq!(le32(&k[0..4]), 5);
-        assert_eq!(&k[4..8], &[0, 0, 0, 0]);
-        assert_eq!(le(&k[8..16]), fnv1a_hash_u64("/etc/shadow"));
-
+    fn the_domain_rule_key_pads_before_the_hash() {
         let d = domain_rule_key(5, "api.example.com");
+        assert_eq!(le32(&d[0..4]), 5);
+        assert_eq!(&d[4..8], &[0, 0, 0, 0]);
         assert_eq!(le(&d[8..16]), fnv1a_hash_u64("api.example.com"));
     }
 
@@ -675,6 +664,54 @@ mod dns_cache_tests {
 /// unpadded `dns_cache_key` hit every time while the padded `domain_rule_key`
 /// beside it missed at random. These tests fail if a padded key is ever
 /// initialized that way again.
+#[cfg(test)]
+mod path_state_chaining {
+    use super::*;
+
+    /// The walk in the BPF program carries the state between components. It
+    /// held that state in a u32 while these values are u64, so every pattern
+    /// with more than one component missed on its second lookup and silently
+    /// fell through to the role default. A single-component pattern kept
+    /// working, which is why it looked like path rules worked at all.
+    #[test]
+    fn intermediate_states_do_not_fit_in_a_u32() {
+        let entries = path_state_entries(7, "/root/secret.txt", false);
+        assert_eq!(entries.len(), 2, "two components, two transitions");
+
+        let next_state = u64::from_ne_bytes(entries[0].1[0..8].try_into().unwrap());
+        assert!(
+            next_state > u64::from(u32::MAX),
+            "intermediate state {next_state:#x} happens to fit in a u32; pick another              pattern for this test, the point is that these values generally do not"
+        );
+    }
+
+    #[test]
+    fn each_component_starts_from_the_state_the_previous_one_produced() {
+        let entries = path_state_entries(7, "/var/lib/data", true);
+        assert_eq!(entries.len(), 3);
+
+        for pair in entries.windows(2) {
+            let produced = u64::from_ne_bytes(pair[0].1[0..8].try_into().unwrap());
+            let consumed = u64::from_ne_bytes(pair[1].0[8..16].try_into().unwrap());
+            assert_eq!(
+                produced, consumed,
+                "the chain only walks if each key resumes from the previous next_state;                  truncating either side breaks every multi-component pattern"
+            );
+        }
+    }
+
+    #[test]
+    fn a_single_component_pattern_terminates_immediately() {
+        let entries = path_state_entries(7, "/root", false);
+        assert_eq!(entries.len(), 1);
+        let next_state = u64::from_ne_bytes(entries[0].1[0..8].try_into().unwrap());
+        assert_eq!(
+            next_state, PATH_STATE_REJECT,
+            "no intermediate state to carry, which is why this kept working"
+        );
+    }
+}
+
 #[cfg(test)]
 mod bpf_key_padding {
     const SRC: &str = include_str!("../../bpfjailer-bpf/src/main.bpf.c");

--- a/bpfjailer-common/src/lib.rs
+++ b/bpfjailer-common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod apply;
 pub mod codec;
 pub mod flags;
 pub mod hash;

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -113,11 +113,6 @@ impl BpfJailerBpf {
         }
         log::info!("✓ network_rules map available for port/protocol filtering");
 
-        if map_by_name(&object, "path_rules").is_none() {
-            return Err(anyhow::anyhow!("path_rules map not found"));
-        }
-        log::info!("✓ path_rules map available for path matching");
-
         if map_by_name(&object, "path_states").is_none() {
             return Err(anyhow::anyhow!("path_states map not found"));
         }
@@ -374,47 +369,6 @@ impl BpfJailerBpf {
         key[4..6].copy_from_slice(&port.to_ne_bytes());
         key[6] = protocol;
         key[7] = direction;
-
-        map.delete(&key)?;
-        Ok(())
-    }
-
-    /// Add a path rule for a role
-    /// path: The path or prefix to match (e.g., "/var/www/", "/tmp/")
-    /// allowed: true = allow, false = deny
-    pub fn add_path_rule(&self, role_id: u32, path: &str, allowed: bool) -> Result<()> {
-        let object = self.object.lock().unwrap();
-        let map = map_by_name(&object, "path_rules")
-            .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
-
-        let key = codec::path_rule_key(role_id, path);
-
-        let value = [if allowed { 1u8 } else { 0u8 }];
-        map.update(&key, &value, MapFlags::empty())?;
-
-        let action = if allowed { "ALLOW" } else { "DENY" };
-        log::info!(
-            "Path rule: role={} path=\"{}\" -> {}",
-            role_id,
-            path,
-            action
-        );
-
-        Ok(())
-    }
-
-    /// Remove a path rule
-    #[allow(dead_code)]
-    pub fn remove_path_rule(&self, role_id: u32, path: &str) -> Result<()> {
-        let object = self.object.lock().unwrap();
-        let map = map_by_name(&object, "path_rules")
-            .ok_or_else(|| anyhow::anyhow!("path_rules map not found"))?;
-
-        let path_hash = bpfjailer_common::hash::fnv1a_hash_u64(path);
-
-        let mut key = [0u8; 16];
-        key[0..4].copy_from_slice(&role_id.to_ne_bytes());
-        key[8..16].copy_from_slice(&path_hash.to_ne_bytes());
 
         map.delete(&key)?;
         Ok(())
@@ -727,7 +681,6 @@ impl BpfJailerBpf {
             "role_flags",
             "pending_enrollments",
             "network_rules",
-            "path_rules",
             "path_states",
             "inode_cache",
             "cache_generation",
@@ -863,7 +816,6 @@ mod root_integration {
             "role_flags",
             "pending_enrollments",
             "network_rules",
-            "path_rules",
             "path_states",
             "inode_cache",
             "exec_enrollment",
@@ -911,17 +863,6 @@ mod root_integration {
         b.remove_network_rule(3, 443, codec::PROTO_TCP, 1)
             .expect("remove");
         assert!(lookup(&b, "network_rules", &key).is_none(), "entry removed");
-    }
-
-    #[test]
-    #[ignore = "requires root"]
-    fn path_rule_round_trips_and_removes() {
-        let b = bpf_or_skip!();
-        b.add_path_rule(1, "/etc/shadow", false).expect("add");
-        let key = codec::path_rule_key(1, "/etc/shadow");
-        assert_eq!(lookup(&b, "path_rules", &key).map(|v| v[0]), Some(0));
-        b.remove_path_rule(1, "/etc/shadow").expect("remove");
-        assert!(lookup(&b, "path_rules", &key).is_none());
     }
 
     #[test]
@@ -1230,14 +1171,13 @@ mod btf_contract {
 
     #[test]
     #[ignore = "requires the built BPF object"]
-    fn domain_and_path_rule_keys_pad_before_the_hash() {
+    fn the_domain_rule_key_pads_before_the_hash() {
         assert_eq!(btf_or_skip!(member_offset("domain_rule_key", "role_id")), 0);
         assert_eq!(
             btf_or_skip!(member_offset("domain_rule_key", "domain_hash")),
             8,
             "4 bytes of padding after role_id"
         );
-        assert_eq!(btf_or_skip!(member_offset("path_rule_key", "path_hash")), 8);
     }
 
     /// The loaded maps report their own key/value sizes, so this catches a

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -250,6 +250,25 @@ impl BpfJailerBpf {
         Ok(result)
     }
 
+    /// Associate a resolved address with the domain it came from, so
+    /// `check_domain_access` can map a connect target back to a name.
+    pub fn cache_resolved_ip(
+        &self,
+        role_id: u32,
+        ip: std::net::Ipv4Addr,
+        domain_hash: u64,
+    ) -> Result<()> {
+        let object = self.object.lock().unwrap();
+        let map = map_by_name(&object, "dns_cache")
+            .ok_or_else(|| anyhow::anyhow!("dns_cache map not found"))?;
+        map.update(
+            &codec::dns_cache_key(role_id, ip),
+            &codec::dns_cache_value(domain_hash, 0),
+            MapFlags::empty(),
+        )?;
+        Ok(())
+    }
+
     pub fn update_pod_role(&self, pod_id: u64, role_id: u32) -> Result<()> {
         let object = self.object.lock().unwrap();
         let map = map_by_name(&object, "pod_to_role")

--- a/bpfjailer-daemon/src/main.rs
+++ b/bpfjailer-daemon/src/main.rs
@@ -89,7 +89,11 @@ async fn main() -> Result<()> {
         let pm = policy_manager.read().await;
         for (name, role) in &pm.config().roles {
             let mut sink = process_tracker::TrackerSink(&process_tracker);
-            match bpfjailer_common::apply::apply_role(&mut sink, role) {
+            match bpfjailer_common::apply::apply_role(
+                &mut sink,
+                role,
+                &bpfjailer_common::apply::SystemResolver,
+            ) {
                 Ok(skipped) => {
                     for s in skipped {
                         warn!("Role '{}': skipped {}", name, s);

--- a/bpfjailer-daemon/src/main.rs
+++ b/bpfjailer-daemon/src/main.rs
@@ -81,31 +81,21 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Apply IP rules, domain rules, and proxy config from policy
+    // Apply every role through the shared walk, so the daemon and the
+    // daemonless bootstrap honour exactly the same sections of a policy.
+    // Enrollment re-applies flags/paths/network per process; the writes are
+    // idempotent, so doing them eagerly here as well is harmless.
     {
         let pm = policy_manager.read().await;
-        for role in pm.config().roles.values() {
-            let role_id = role.id;
-
-            // Apply IP rules
-            if !role.ip_rules.is_empty() {
-                if let Err(e) = process_tracker.apply_ip_rules(role_id, &role.ip_rules) {
-                    warn!("Failed to apply IP rules for role {}: {}", role_id.0, e);
+        for (name, role) in &pm.config().roles {
+            let mut sink = process_tracker::TrackerSink(&process_tracker);
+            match bpfjailer_common::apply::apply_role(&mut sink, role) {
+                Ok(skipped) => {
+                    for s in skipped {
+                        warn!("Role '{}': skipped {}", name, s);
+                    }
                 }
-            }
-
-            // Apply domain rules
-            if !role.domain_rules.is_empty() {
-                if let Err(e) = process_tracker.apply_domain_rules(role_id, &role.domain_rules) {
-                    warn!("Failed to apply domain rules for role {}: {}", role_id.0, e);
-                }
-            }
-
-            // Apply proxy config
-            if let Some(ref proxy) = role.proxy {
-                if let Err(e) = process_tracker.set_proxy_config(role_id, proxy) {
-                    warn!("Failed to set proxy config for role {}: {}", role_id.0, e);
-                }
+                Err(e) => warn!("Failed to apply role '{}': {}", name, e),
             }
         }
     }

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -244,6 +244,15 @@ impl bpfjailer_common::apply::PolicySink for TrackerSink<'_> {
     fn add_domain_rule(&mut self, role_id: u32, domain: &str, allow: bool) -> Result<()> {
         self.0.add_domain_rule(RoleId(role_id), domain, allow)
     }
+    fn cache_resolved_ip(
+        &mut self,
+        role_id: u32,
+        ip: std::net::Ipv4Addr,
+        domain_hash: u64,
+    ) -> Result<()> {
+        self.0.bpf.cache_resolved_ip(role_id, ip, domain_hash)
+    }
+
     fn set_proxy(&mut self, role_id: u32, address: &str, required: bool) -> Result<()> {
         self.0.set_proxy_config(
             RoleId(role_id),

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -139,14 +139,6 @@ impl ProcessTracker {
         Ok(())
     }
 
-    /// Add a path rule for a role (legacy hash-based)
-    #[allow(dead_code)]
-    pub fn add_path_rule(&self, role_id: RoleId, path: &str, allowed: bool) -> Result<()> {
-        self.bpf
-            .add_path_rule(role_id.0, path, allowed)
-            .context("Failed to add path rule")
-    }
-
     /// Add a path state (dentry-walking state machine)
     pub fn add_path_state(&self, role_id: RoleId, pattern: &str, allowed: bool) -> Result<()> {
         self.bpf
@@ -429,12 +421,10 @@ mod root_integration {
 
     #[test]
     #[ignore = "requires root"]
-    fn add_path_state_and_path_rule_are_both_accepted() {
+    fn add_path_state_is_accepted() {
         let t = tracker_or_skip!();
         t.add_path_state(RoleId(26), "/srv/data/", false)
             .expect("state");
-        t.add_path_rule(RoleId(26), "/srv/data/secret", false)
-            .expect("rule");
     }
 
     #[test]

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -1,8 +1,6 @@
 use crate::bpf_loader::BpfJailerBpf;
 use anyhow::{Context, Result};
-use bpfjailer_common::{
-    DomainRule, IpRule, NetworkRule, PathPattern, PodId, PolicyFlags, ProxyConfig, RoleId,
-};
+use bpfjailer_common::{NetworkRule, PathPattern, PodId, PolicyFlags, ProxyConfig, RoleId};
 use log::{debug, info, warn};
 use std::sync::Arc;
 
@@ -197,25 +195,6 @@ impl ProcessTracker {
             .context("Failed to add IP rule")
     }
 
-    /// Apply IP rules from a Role definition
-    pub fn apply_ip_rules(&self, role_id: RoleId, rules: &[IpRule]) -> Result<()> {
-        for rule in rules {
-            let direction = match rule.direction.to_lowercase().as_str() {
-                "bind" => DIR_BIND,
-                "connect" => DIR_CONNECT,
-                _ => DIR_CONNECT, // Default to connect for egress control
-            };
-
-            self.add_ip_rule(role_id, &rule.cidr, direction, rule.allow)?;
-
-            info!(
-                "Applied IP rule: role={} cidr={} direction={} allow={}",
-                role_id.0, rule.cidr, rule.direction, rule.allow
-            );
-        }
-        Ok(())
-    }
-
     /// Configure proxy requirement for a role
     pub fn set_proxy_config(&self, role_id: RoleId, config: &ProxyConfig) -> Result<()> {
         self.bpf
@@ -229,18 +208,50 @@ impl ProcessTracker {
             .add_domain_rule(role_id.0, domain, allowed)
             .context("Failed to add domain rule")
     }
+}
 
-    /// Apply domain rules from a Role definition
-    pub fn apply_domain_rules(&self, role_id: RoleId, rules: &[DomainRule]) -> Result<()> {
-        for rule in rules {
-            self.add_domain_rule(role_id, &rule.domain, rule.allow)?;
+/// Writes role rules through the tracker's BPF handle.
+///
+/// Lets the daemon apply a policy through the same
+/// [`bpfjailer_common::apply::apply_role`] walk the bootstrap uses, so the two
+/// cannot disagree about which sections of a role are honoured.
+pub struct TrackerSink<'a>(pub &'a ProcessTracker);
 
-            info!(
-                "Applied domain rule: role={} domain={} allow={}",
-                role_id.0, rule.domain, rule.allow
-            );
-        }
-        Ok(())
+impl bpfjailer_common::apply::PolicySink for TrackerSink<'_> {
+    type Err = anyhow::Error;
+
+    fn set_role_flags(&mut self, role_id: u32, flags: u8) -> Result<()> {
+        self.0.bpf.update_role_flags(role_id, flags)
+    }
+    fn add_path_state(&mut self, role_id: u32, pattern: &str, allow: bool) -> Result<()> {
+        self.0.bpf.add_path_state(role_id, pattern, allow)
+    }
+    fn add_network_rule(
+        &mut self,
+        role_id: u32,
+        port: u16,
+        protocol: u8,
+        direction: u8,
+        allow: bool,
+    ) -> Result<()> {
+        self.0
+            .bpf
+            .add_network_rule(role_id, port, protocol, direction, allow)
+    }
+    fn add_ip_rule(&mut self, role_id: u32, cidr: &str, direction: u8, allow: bool) -> Result<()> {
+        self.0.add_ip_rule(RoleId(role_id), cidr, direction, allow)
+    }
+    fn add_domain_rule(&mut self, role_id: u32, domain: &str, allow: bool) -> Result<()> {
+        self.0.add_domain_rule(RoleId(role_id), domain, allow)
+    }
+    fn set_proxy(&mut self, role_id: u32, address: &str, required: bool) -> Result<()> {
+        self.0.set_proxy_config(
+            RoleId(role_id),
+            &ProxyConfig {
+                address: address.to_string(),
+                required,
+            },
+        )
     }
 }
 


### PR DESCRIPTION
The daemonless bootstrap and the daemon each walked a `Role` and wrote it into the BPF maps, and the two walks had drifted: the bootstrap silently ignored `ip_rules`, `domain_rules` and `proxy`. A policy that used them loaded without complaint and enforced nothing.

Both modes now go through one `apply_role` in `bpfjailer-common`, over a `PolicySink` trait implemented by each. A rule that cannot be represented is returned as a skipped-rule description rather than dropped. `apply_role_covers_every_enforcing_field` fails if a new enforcing field is added to `Role` without being applied.

### domain_rules had no enforcement at all

Neither half existed: nothing in the BPF programs read `dns_cache` or `domain_rules`, and userspace only logged that the map was present. `check_domain_access` now resolves a connect target through `dns_cache` to a domain hash and looks that up in `domain_rules`, ahead of the IP rules. Policy load resolves each domain rule and caches the resulting addresses.

The limits are worth stating: this matches on address, so an address that changes after load is not covered, hosts sharing an address collide, and a process that resolves a name itself and then connects elsewhere is not caught.

### Padded key structs made lookups nondeterministic

Verifying the above on a live appliance turned up a separate, older bug. A BPF hash lookup compares the whole key, padding included, and four key structs carry alignment padding:

| struct | padding |
|---|---|
| `path_state_key` | 4 bytes before `.state` |
| `inode_cache_key` | 4 bytes before `.inode` |
| `path_rule_key` | 4 bytes before `.path_hash` |
| `domain_rule_key` | 4 bytes before `.domain_hash` |

Three were built with an initializer list, which sets the named members and leaves the padding as whatever the stack held, so the lookup matched only when those bytes were zero. Measured on a real boot, a domain rule denied roughly one connect in three. The trace showed why: the unpadded `dns_cache_key` hit every time and returned the correct hash, while the padded `domain_rule_key` lookup beside it missed at random. `path_state_key` and `inode_cache_key` share the defect, so file path matching was affected too.

Each key is now declared, `__builtin_memset` to zero, then assigned.

### Verification

On a booted appliance, an enrolled binary against an identical un-enrolled copy of itself:

| case | result |
|---|---|
| `domain_rules` deny, enrolled, 20 runs | 20/20 `EACCES` |
| same binary, not enrolled, 5 runs | 5/5 allowed |
| `path_rules`, path outside the allow list, 10 runs | 10/10 `EACCES` |
| control, 3 runs | 3/3 allowed |

Before the padding fix the first row was 3/8. The probe reports `errno`, because a failed connect and a policy denial are otherwise indistinguishable — an earlier bash `/dev/tcp` test conflated the two and read as flaky enforcement when it was partly an unreliable target.

### Guard

`codec.rs` parses the BPF source, derives which key structs the C layout rules pad, and fails if any is built with an initializer list. Reintroducing the initializer list on `domain_rule_key` makes it fail. It sits in `bpfjailer-common` because the CI unit-test job runs `--lib` and `bpfjailer-daemon` has no library target.

fmt, machete, clippy `--deny warnings`, doc `-D warnings` and 167 tests pass.