### PR TITLE
Assert every declared map is read by a BPF program, and drop pod_to_role

### DIFF
--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -290,14 +290,6 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
     }
 
     // Load pod mappings
-    if let Some(map) = map_by_name(object, "pod_to_role") {
-        for pod in &policy.pods {
-            let key = pod.id.to_ne_bytes();
-            let value = pod.role_id.0.to_ne_bytes();
-            map.update(&key, &value, MapFlags::empty())?;
-            log::info!("Pod {} -> role {}", pod.id, pod.role_id.0);
-        }
-    }
 
     // Load exec enrollments
     if let Some(map) = map_by_name(object, "exec_enrollment") {
@@ -376,7 +368,6 @@ fn pin_all(object: &mut Object, links: &mut [Link]) -> Result<()> {
     // Pin all maps
     let map_names = [
         "task_storage",
-        "pod_to_role",
         "role_flags",
         "pending_enrollments",
         "network_rules",
@@ -579,22 +570,6 @@ mod root_integration {
                 .expect("transition present");
             assert_eq!(got.as_slice(), value.as_slice());
         }
-    }
-
-    #[test]
-    #[ignore = "requires root"]
-    fn populate_maps_writes_pod_to_role() {
-        let Some(mut object) = loaded_object() else {
-            return;
-        };
-        let cfg: PolicyConfig = serde_json::from_str(POLICY).expect("parse");
-        populate_maps(&mut object, &cfg).expect("populate");
-        let v = map_by_name(&object, "pod_to_role")
-            .expect("map")
-            .lookup(&300u64.to_ne_bytes(), MapFlags::empty())
-            .expect("lookup")
-            .expect("pod present");
-        assert_eq!(u32::from_ne_bytes(v[0..4].try_into().unwrap()), 30);
     }
 
     #[test]

--- a/bpfjailer-bpf/src/main.bpf.c
+++ b/bpfjailer-bpf/src/main.bpf.c
@@ -33,13 +33,6 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 1024);
-    __type(key, u64);
-    __type(value, u32);
-} pod_to_role SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, 1024);
     __type(key, u32);
     __type(value, u8);
 } role_flags SEC(".maps");

--- a/bpfjailer-common/src/bpf_contract.rs
+++ b/bpfjailer-common/src/bpf_contract.rs
@@ -1,0 +1,120 @@
+//! Structural checks on the BPF source.
+//!
+//! Each defect found so far had the same shape: userspace writes a map that no
+//! BPF program ever reads. `path_rules` was declared "legacy, kept for
+//! compatibility" and populated for years without being consulted;
+//! `domain_rules` was written at every policy load while nothing in the kernel
+//! looked at it. Both read as enforcement from the outside -- the maps exist,
+//! the entries are there, `bpftool map dump` shows them.
+//!
+//! Nothing links the two halves, so the tests here assert the link directly.
+
+#[cfg(test)]
+mod map_has_a_bpf_side_reader {
+    /// `bpfjailer-bpf/build.rs` lists five `.bpf.c` files for
+    /// `rerun-if-changed`, but calls `compile_bpf_program` on `main.bpf.c`
+    /// alone. That one file is the whole loaded object, so it is the only one
+    /// whose maps can enforce anything, and the only one checked here.
+    ///
+    /// The other four are compiled by nothing and loaded by nothing. Their
+    /// maps are unreachable no matter what userspace writes to them.
+    const SOURCE: &str = include_str!("../../bpfjailer-bpf/src/main.bpf.c");
+
+    /// Comments are stripped before anything is matched: a map named only in a
+    /// `// TODO: read foo_map here` would otherwise count as a use.
+    fn without_comments(src: &str) -> String {
+        let mut out = String::with_capacity(src.len());
+        let mut chars = src.chars().peekable();
+        let mut in_block = false;
+        while let Some(c) = chars.next() {
+            if in_block {
+                if c == '*' && chars.peek() == Some(&'/') {
+                    chars.next();
+                    in_block = false;
+                }
+                continue;
+            }
+            match (c, chars.peek()) {
+                ('/', Some('*')) => {
+                    chars.next();
+                    in_block = true;
+                }
+                ('/', Some('/')) => {
+                    for c in chars.by_ref() {
+                        if c == '\n' {
+                            out.push('\n');
+                            break;
+                        }
+                    }
+                }
+                _ => out.push(c),
+            }
+        }
+        out
+    }
+
+    /// Names declared as `} <name> SEC(".maps");`.
+    fn declared_maps(src: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        for (idx, _) in src.match_indices("SEC(\".maps\")") {
+            let head = &src[..idx];
+            let Some(brace) = head.rfind('}') else {
+                continue;
+            };
+            let name = head[brace + 1..].trim();
+            if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                out.push(name.to_string());
+            }
+        }
+        out
+    }
+
+    /// True if the map's address is taken anywhere in the BPF sources. Any
+    /// argument position counts: `bpf_perf_event_output` takes the map second,
+    /// so matching only the first argument would wrongly flag `audit_events`.
+    fn is_referenced(body: &str, name: &str) -> bool {
+        body.match_indices(&format!("&{name}")).any(|(i, _)| {
+            body[i + name.len() + 1..]
+                .chars()
+                .next()
+                .is_none_or(|c| !c.is_alphanumeric() && c != '_')
+        })
+    }
+
+    fn stripped() -> String {
+        without_comments(SOURCE)
+    }
+
+    #[test]
+    fn the_parser_still_finds_the_maps() {
+        let body = stripped();
+        let maps = declared_maps(&body);
+        assert!(
+            maps.len() >= 10,
+            "expected to find the map declarations, found {maps:?} -- the parser has \
+             drifted from the source and is checking nothing"
+        );
+        assert!(
+            maps.iter().any(|m| m == "role_flags"),
+            "role_flags is central to every hook; not finding it means the parser is broken"
+        );
+    }
+
+    #[test]
+    fn every_declared_map_is_used_by_a_bpf_program() {
+        let body = stripped();
+        let unused: Vec<String> = declared_maps(&body)
+            .into_iter()
+            .filter(|m| !is_referenced(&body, m))
+            .collect();
+
+        assert!(
+            unused.is_empty(),
+            "these maps are declared, and userspace can pin and populate them, but no \
+             BPF program ever touches them: {unused:?}. Such a map looks like \
+             enforcement from the outside -- it exists, it has entries -- and enforces \
+             nothing. Either wire it up in the BPF program or delete it; do not leave \
+             it declared."
+        );
+    }
+}

--- a/bpfjailer-common/src/lib.rs
+++ b/bpfjailer-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod apply;
+mod bpf_contract;
 pub mod codec;
 pub mod flags;
 pub mod hash;

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -97,9 +97,6 @@ impl BpfJailerBpf {
         log::info!("BPF object loaded successfully");
 
         // Check that maps exist
-        if map_by_name(&object, "pod_to_role").is_none() {
-            return Err(anyhow::anyhow!("pod_to_role map not found"));
-        }
         if map_by_name(&object, "role_flags").is_none() {
             return Err(anyhow::anyhow!("role_flags map not found"));
         }
@@ -261,16 +258,6 @@ impl BpfJailerBpf {
             &codec::dns_cache_value(domain_hash, 0),
             MapFlags::empty(),
         )?;
-        Ok(())
-    }
-
-    pub fn update_pod_role(&self, pod_id: u64, role_id: u32) -> Result<()> {
-        let object = self.object.lock().unwrap();
-        let map = map_by_name(&object, "pod_to_role")
-            .ok_or_else(|| anyhow::anyhow!("pod_to_role map not found"))?;
-        let key = pod_id.to_ne_bytes();
-        let value = role_id.to_ne_bytes();
-        map.update(&key, &value, MapFlags::empty())?;
         Ok(())
     }
 
@@ -677,7 +664,6 @@ impl BpfJailerBpf {
         // Pin maps
         let map_names = [
             "task_storage",
-            "pod_to_role",
             "role_flags",
             "pending_enrollments",
             "network_rules",
@@ -812,7 +798,6 @@ mod root_integration {
         let b = bpf_or_skip!();
         let object = b.object.lock().unwrap();
         for name in [
-            "pod_to_role",
             "role_flags",
             "pending_enrollments",
             "network_rules",
@@ -827,15 +812,6 @@ mod root_integration {
         ] {
             assert!(map_by_name(&object, name).is_some(), "map {name} missing");
         }
-    }
-
-    #[test]
-    #[ignore = "requires root"]
-    fn pod_role_round_trips() {
-        let b = bpf_or_skip!();
-        b.update_pod_role(4242, 7).expect("update");
-        let v = lookup(&b, "pod_to_role", &4242u64.to_ne_bytes()).expect("entry present");
-        assert_eq!(u32::from_ne_bytes(v[0..4].try_into().unwrap()), 7);
     }
 
     #[test]

--- a/bpfjailer-daemon/src/process_tracker.rs
+++ b/bpfjailer-daemon/src/process_tracker.rs
@@ -28,11 +28,6 @@ impl ProcessTracker {
             pid, pod_id.0, role_id.0
         );
 
-        // Update pod_to_role mapping
-        self.bpf
-            .update_pod_role(pod_id.0, role_id.0)
-            .context("Failed to insert pod_to_role mapping")?;
-
         // Add to pending_enrollments map - BPF will migrate to task_storage
         // on the next syscall (file_open, exec, etc.)
         self.bpf


### PR DESCRIPTION
Every map defect found so far has the same shape: **userspace writes a map that no BPF program ever reads.**

- `path_rules` — declared "legacy, kept for compatibility", populated, never consulted
- `domain_rules` — written at every policy load while nothing in the kernel looked at it

Both read as enforcement from the outside: the map exists, it has entries, `bpftool map dump` shows them. Nothing structural linked the two halves, so each was found by hand, one at a time. This asserts the link.

## The guard

Parses the BPF source, collects every `} name SEC(".maps")`, and fails if the map's address is never taken anywhere in the program. Two details that matter:

- **Comments are stripped first** — a map named only in a `// TODO: read this here` would otherwise count as a use.
- **Any argument position counts** — `bpf_perf_event_output` takes the map *second*, so matching only the first argument wrongly flags `audit_events`. I hit that while writing it.

## It found `pod_to_role` immediately

The daemon wrote it on every enrollment, the bootstrap populated it, it was pinned, and load *failed* if it was absent. No BPF program read it. The only readers anywhere were two tests. `task_storage` already carries `pod_id` beside `role_id`, which is what the hooks actually use — so the map was pure bookkeeping that nothing consulted. Removed.

## Scope, and a finding left open

The guard checks `main.bpf.c` only, because that is the entire loaded object. `build.rs` lists five `.bpf.c` files for `rerun-if-changed` and then calls `compile_bpf_program` on `main.bpf.c` alone:

| file | compiled |
|---|---|
| `main.bpf.c` | yes |
| `process_tracking.bpf.c` | no |
| `path_matching.bpf.c` | no |
| `networking.bpf.c` | no |
| `signed_binary.bpf.c` | no |

The other four are compiled by nothing and loaded by nothing. Their maps — `path_patterns`, `allowed_ports`, `allowed_addresses`, `verified_binaries` — are unreachable no matter what userspace writes to them, and editing those files has no effect on the running program.

**I have not deleted them.** They may be intended work, and that is a call for the maintainer rather than a side effect of adding a test. Worth noting the `build.rs` list actively implies they are built.

## Verification

The removed map sat in the enrollment path, so on a booted appliance, with a deny rule on `/root/secret.txt`:

| case | result |
|---|---|
| jailed, `/root/secret.txt` | 5/5 denied |
| jailed, `/root/other.txt` (same dir, not covered) | 5/5 allowed |
| control `/bin/cat` | 3/3 allowed |

fmt, machete, clippy `--deny warnings`, doc `-D warnings`, 123 tests pass.