### PR TITLE
Match ancestor cgroups when enrolling, so a policy can name a stable cgroup

### DIFF
--- a/bpfjailer-bootstrap/src/main.rs
+++ b/bpfjailer-bootstrap/src/main.rs
@@ -324,6 +324,11 @@ fn populate_maps(object: &mut Object, policy: &PolicyConfig) -> Result<()> {
         for enrollment in &policy.cgroup_enrollments {
             if let Ok(metadata) = fs::metadata(&enrollment.cgroup_path) {
                 let cgroup_id = metadata.ino();
+                if let Err(reason) =
+                    bpfjailer_common::cgroup::check_enrollable(&enrollment.cgroup_path, cgroup_id)
+                {
+                    return Err(anyhow::anyhow!("cgroup enrollment refused: {reason}"));
+                }
                 if let Some(role) = policy.get_role(&enrollment.role) {
                     let key = cgroup_id.to_ne_bytes();
                     let mut value = [0u8; 16];

--- a/bpfjailer-bpf/src/main.bpf.c
+++ b/bpfjailer-bpf/src/main.bpf.c
@@ -152,6 +152,12 @@ struct {
     __type(value, struct exec_enrollment_value);
 } cgroup_enrollment SEC(".maps");
 
+// How far up the cgroup tree an enrollment is looked for. A kubelet nests
+// containers four deep (kubepods.slice / qos.slice / pod.slice / container
+// .scope); eight leaves room for deeper systemd nesting without unrolling a
+// loop the verifier has to walk on every exec.
+#define MAX_CGROUP_DEPTH 8
+
 // =============================================================================
 // IP/CIDR Egress Filtering
 // =============================================================================
@@ -1002,8 +1008,33 @@ int BPF_PROG(bprm_check_security, struct linux_binprm *bprm)
 
     // If still not enrolled, check for auto-enrollment by cgroup
     if (info->pod_id == 0) {
+        // Match the task's own cgroup first, then walk its ancestry, so an
+        // enrollment covers a cgroup and everything beneath it.
+        //
+        // Without this only the leaf matches. Under a kubelet the leaf is the
+        // container scope, whose name carries the container id, so a policy
+        // could only name an object that is replaced on every restart and
+        // enforcement lapsed silently on any rollout. Ancestor matching lets a
+        // policy name a stable cgroup -- a pod slice, or kubepods.slice, which
+        // exists before any pod is scheduled.
+        //
+        // Deepest first, so a container-scope rule still beats a pod rule and a
+        // pod rule still beats a node-wide one. Level 0 is the cgroup root and
+        // is deliberately not consulted: it is every process on the host, and
+        // the loader refuses to enroll it.
         u64 cgroup_id = bpf_get_current_cgroup_id();
         struct exec_enrollment_value *enroll = bpf_map_lookup_elem(&cgroup_enrollment, &cgroup_id);
+
+        #pragma unroll
+        for (int lvl = MAX_CGROUP_DEPTH; lvl > 0; lvl--) {
+            if (enroll)
+                break;
+            // Returns 0 when the task's cgroup is shallower than this level.
+            u64 ancestor_id = bpf_get_current_ancestor_cgroup_id(lvl);
+            if (ancestor_id)
+                enroll = bpf_map_lookup_elem(&cgroup_enrollment, &ancestor_id);
+        }
+
         if (enroll) {
             // Auto-enroll based on cgroup
             info->pod_id = enroll->pod_id;

--- a/bpfjailer-common/src/bpf_contract.rs
+++ b/bpfjailer-common/src/bpf_contract.rs
@@ -85,6 +85,22 @@ mod map_has_a_bpf_side_reader {
         without_comments(SOURCE)
     }
 
+    /// Enrollment matches `bpf_get_current_cgroup_id()`, the task's *leaf*
+    /// cgroup. Under a kubelet the leaf is the container scope, whose name
+    /// carries the container id, so a policy could only ever name an object
+    /// that is replaced on every restart -- enforcement silently lapsed on any
+    /// rollout. Matching ancestors as well is what lets a policy name a stable
+    /// cgroup such as `kubepods.slice`.
+    #[test]
+    fn the_exec_hook_matches_ancestor_cgroups_not_only_the_leaf() {
+        let body = stripped();
+        assert!(
+            body.contains("bpf_get_current_ancestor_cgroup_id"),
+            "nothing walks the cgroup ancestry, so only the leaf cgroup can be \
+             enrolled and enrollment cannot survive a container restart"
+        );
+    }
+
     #[test]
     fn the_parser_still_finds_the_maps() {
         let body = stripped();

--- a/bpfjailer-common/src/cgroup.rs
+++ b/bpfjailer-common/src/cgroup.rs
@@ -1,0 +1,67 @@
+//! Rules about which cgroups may be enrolled.
+//!
+//! An enrollment covers a cgroup and everything beneath it, which is what lets
+//! a policy name something stable like `kubepods.slice` instead of a container
+//! scope that is replaced on every restart.
+//!
+//! It also means a high-level enrollment captures more than the workload. A
+//! container runtime does its setup *inside* the container's cgroup: runc's
+//! `nsexec` opens `/proc/<pid>/ns/*`, which the kernel gates behind
+//! `ptrace_may_access()`. A node-wide role with `allow_ptrace: false`
+//! therefore stops containers from starting at all, with the failure surfacing
+//! as a runtime error rather than a policy denial:
+//!
+//! ```text
+//! runc create failed: unable to start container process:
+//!   nsexec-1: failed to open /proc/32735/ns/ipc: Permission denied
+//! ```
+//!
+//! Roles attached at or above the pod slice have to be permissive enough for
+//! the runtime that starts the workload, not only for the workload itself.
+
+/// Inode of the cgroup root. Enrollment matches a cgroup *and its
+/// descendants*, and every process on the host descends from the root, so an
+/// enrollment here would jail the kubelet, the container runtime, sshd and the
+/// loader itself.
+pub const ROOT_CGROUP_INO: u64 = 1;
+
+/// Whether a cgroup may carry an enrollment.
+pub fn check_enrollable(path: &str, ino: u64) -> Result<(), String> {
+    if ino == ROOT_CGROUP_INO {
+        return Err(format!(
+            "{path} is the cgroup root; enrolling it would apply the role to every \
+             process on the host, including the container runtime and this loader"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_root_cgroup_is_refused() {
+        let err = check_enrollable("/sys/fs/cgroup", ROOT_CGROUP_INO)
+            .expect_err("enrolling the root cgroup must be refused");
+        assert!(
+            err.contains("/sys/fs/cgroup"),
+            "the error should name the offending path, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_pod_slice_is_accepted() {
+        assert!(check_enrollable(
+            "/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice",
+            5717
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn the_node_wide_pod_slice_is_accepted() {
+        // The whole point of ancestor matching: this must be enrollable.
+        assert!(check_enrollable("/sys/fs/cgroup/kubepods.slice", 5287).is_ok());
+    }
+}

--- a/bpfjailer-common/src/lib.rs
+++ b/bpfjailer-common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod apply;
 mod bpf_contract;
+pub mod cgroup;
 pub mod codec;
 pub mod flags;
 pub mod hash;

--- a/test/k8s-cgroup-enrollment.sh
+++ b/test/k8s-cgroup-enrollment.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Acceptance test: can a jailer policy jail k8s pods without naming a
+# container id? Enrolls the static kubepods.slice and asserts the rule bites
+# both immediately and after the pod is recreated.
+#
+# Run on the k3s node.
+set -uo pipefail
+export PATH=/opt/bin:$PATH KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+PASS=0; FAIL=0
+check() { # check <label> <expected ALLOWED|DENIED> <actual>
+  if [ "$2" = "$3" ]; then echo "  PASS  $1 ($3)"; PASS=$((PASS+1))
+  else echo "  FAIL  $1 (expected $2, got $3)"; FAIL=$((FAIL+1)); fi
+}
+# A pod that cannot start also cannot connect, and scoring that as DENIED
+# turns a broken cluster into a passing test. Assert the pod is actually
+# running, and distinguish a failed exec from a refused connection.
+require_running() {
+  local phase ready
+  phase=$(kubectl get pod victim -o jsonpath='{.status.phase}' 2>/dev/null)
+  ready=$(kubectl get pod victim -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null)
+  [ "$phase" = Running ] && [ "$ready" = true ]
+}
+probe() { # pod -> node:9999
+  if ! require_running; then echo "POD-NOT-RUNNING"; return; fi
+  local out rc
+  out=$(kubectl exec victim -- nc -w3 10.0.2.15 9999 </dev/null 2>&1); rc=$?
+  if [ $rc -eq 0 ]; then echo ALLOWED
+  elif echo "$out" | grep -qiE "error from server|unable to upgrade|container not found|not running"; then
+    echo "EXEC-FAILED"
+  else echo DENIED; fi
+}
+node_probe() { nc -w3 10.0.2.15 9999 </dev/null >/dev/null 2>&1 && echo ALLOWED || echo DENIED; }
+
+python3 - <<'PY'
+import json
+p='/etc/bpfjailer/policy.json'; d=json.load(open(p))
+d['roles']['k8s']={'id':30,'name':'k8s',
+ 'flags':{'allow_file_access':True,'allow_network':True,'allow_exec':True,
+          'require_signed_binary':False,'allow_setuid':True,'allow_ptrace':True},
+ 'file_paths':[],'network_rules':[],'execution_rules':[],'require_signed_binary':False,
+ 'domain_rules':[],
+ 'ip_rules':[{'cidr':'10.0.2.15/32','direction':'connect','allow':False}]}
+d['exec_enrollments']=[]
+# The whole point: name only the static slice, never a container id.
+d['cgroup_enrollments']=[{'cgroup_path':'/sys/fs/cgroup/kubepods.slice','pod_id':7001,'role':'k8s'}]
+json.dump(d,open(p,'w'),indent=2)
+PY
+rm -rf /sys/fs/bpf/bpfjailer && systemctl restart bpfjailer-bootstrap && sleep 3
+[ "$(systemctl is-active bpfjailer-bootstrap)" = active ] \
+  && echo "  PASS  bootstrap accepts a kubepods.slice enrollment" && PASS=$((PASS+1)) \
+  || { echo "  FAIL  bootstrap did not start"; FAIL=$((FAIL+1)); }
+
+check "pod is jailed via the node-wide slice"      DENIED  "$(probe)"
+check "node processes are unaffected"              ALLOWED "$(node_probe)"
+
+kubectl delete pod victim --wait=true >/dev/null 2>&1
+cat <<'YAML' | kubectl apply -f - >/dev/null 2>&1
+apiVersion: v1
+kind: Pod
+metadata: {name: victim}
+spec:
+  containers:
+  - {name: shell, image: busybox:1.36, command: ['sh','-c','while true; do sleep 5; done']}
+YAML
+kubectl wait --for=condition=Ready pod/victim --timeout=180s >/dev/null 2>&1
+require_running \
+  && { echo "  PASS  pod actually starts under the enrollment"; PASS=$((PASS+1)); } \
+  || { echo "  FAIL  pod did not start under the enrollment"; FAIL=$((FAIL+1)); }
+check "enforcement survives pod recreation"        DENIED  "$(probe)"
+
+echo "  ---- $PASS passed, $FAIL failed ----"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Tested on a real kubelet for the first time (k3s v1.36.2, containerd 2.3.2, systemd cgroup driver, BPF LSM active). Enforcement worked — but only if the policy named the one thing on the node guaranteed to change.

## What was wrong

Enrollment matched `bpf_get_current_cgroup_id()`, the task's **leaf** cgroup. Under a kubelet that is the container scope:

```
kubepods.slice / kubepods-besteffort.slice
  / kubepods-besteffort-pod<uid>.slice
    / cri-containerd-<container-id>.scope   <- only this matched
```

| enrolled | result |
|---|---|
| pod slice (ino 7186) | 5/5 allowed — **no enforcement** |
| container scope (ino 7366) | 5/5 denied |
| after `delete pod` + recreate | live scope ino **8545** → 5/5 **allowed** |

So policy could only name an object whose inode changes on every container start, and enforcement lapsed on any rollout, reschedule or crash-restart — with no error and no log line. The bootstrap still reported `Cgroup enrollment: … -> pod=7001, role=k8s` and looked healthy.

## The fix

The exec hook checks the leaf, then walks the ancestry deepest-first, so an enrollment covers a cgroup and everything beneath it:

| enroll | covers | survives |
|---|---|---|
| `kubepods.slice` | every pod on the node | everything — **and applies at boot, before any pod exists** |
| `…pod<uid>.slice` | all containers in that pod | container restarts |
| `…<id>.scope` | one container (previous behaviour) | nothing |

The first row is the point: a node-wide baseline needs **no container discovery at all**, which also closes the window where a container runs unjailed until something notices it. Cost is per-`exec` only — enrollment happens in `bprm_check_security`, not per-syscall.

Level 0 (the cgroup root) is not consulted, and the loader refuses to enroll it: it would apply the role to every process on the host, including the runtime and the loader.

## Verified on the k3s node

| check | result |
|---|---|
| pod jailed via `kubepods.slice` | denied |
| node processes unaffected | allowed |
| pod actually starts under the enrollment | Running, 0 restarts |
| enforcement survives pod recreation | denied |
| target outside the rule (`10.43.0.1:443`) | allowed — selective, not blanket |
| container-scope role vs node-wide role | container rule wins |

## Two things the testing turned up

**A node-wide role captures the container runtime, not just the workload.** runc's `nsexec` opens `/proc/<pid>/ns/*`, which the kernel gates behind `ptrace_may_access()`, so a role with `allow_ptrace: false` stops containers starting entirely:

```
runc create failed: unable to start container process:
  nsexec-1: failed to open /proc/32735/ns/ipc: Permission denied
```

It surfaces as an OCI runtime error, not a policy denial, so it is easy to misread. Documented on the cgroup module — roles attached at or above the pod slice must be permissive enough for the runtime that starts the workload.

**The first acceptance test was wrong.** It scored a failed `kubectl exec` as a denial, so a cluster broken by exactly the above passed as "enforcement working". It now asserts the pod is `Running` and separates `EXEC-FAILED` from `DENIED`. The test is included as `test/k8s-cgroup-enrollment.sh`; it fails on the old code for the right reason.

fmt, machete, clippy `--deny warnings`, doc `-D warnings`, 127 tests pass.