### PR TITLE
Let a role be defined at runtime, and let the daemon find an installed object

### DIFF
--- a/bpfjailer-client/src/enrollment.rs
+++ b/bpfjailer-client/src/enrollment.rs
@@ -22,6 +22,12 @@ pub enum EnrollmentRequest {
     RemoveExecutable {
         executable_path: String,
     },
+    /// Install or replace a role, so a caller deciding policy at runtime can
+    /// enroll against it. Without this, enrollment can only name roles that
+    /// were in the policy file the daemon started with.
+    DefineRole {
+        role: bpfjailer_common::policy::Role,
+    },
     EnrollCgroup {
         cgroup_path: String,
         pod_id: PodId,

--- a/bpfjailer-common/src/bpf_contract.rs
+++ b/bpfjailer-common/src/bpf_contract.rs
@@ -9,6 +9,36 @@
 //!
 //! Nothing links the two halves, so the tests here assert the link directly.
 
+/// The bootstrap and the daemon each search for the compiled object
+/// independently. They disagreed: the bootstrap looked in the installed
+/// locations and the daemon only in cargo build trees, so a packaged daemon
+/// could not start at all while the bootstrap on the same host worked.
+#[cfg(test)]
+mod loaders_agree_on_installed_paths {
+    const BOOTSTRAP: &str = include_str!("../../bpfjailer-bootstrap/src/main.rs");
+    const DAEMON: &str = include_str!("../../bpfjailer-daemon/src/bpf_loader.rs");
+
+    const INSTALLED: [&str; 2] = [
+        "/usr/lib/bpfjailer/bpfjailer.bpf.o",
+        "/usr/share/bpfjailer/bpfjailer.bpf.o",
+    ];
+
+    #[test]
+    fn both_loaders_search_the_installed_locations() {
+        for path in INSTALLED {
+            assert!(
+                BOOTSTRAP.contains(path),
+                "the bootstrap no longer looks in {path}"
+            );
+            assert!(
+                DAEMON.contains(path),
+                "the daemon does not look in {path}, so it cannot start from an \
+                 installed package even where the bootstrap can"
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod map_has_a_bpf_side_reader {
     /// `bpfjailer-bpf/build.rs` lists five `.bpf.c` files for

--- a/bpfjailer-daemon/src/bpf_loader.rs
+++ b/bpfjailer-daemon/src/bpf_loader.rs
@@ -45,6 +45,11 @@ impl BpfJailerBpf {
             .unwrap_or_else(|| PathBuf::from("."));
 
         let possible_paths = [
+            // Installed locations first, and searched at all: without them the
+            // daemon only ever found the object inside a cargo build tree, so
+            // it could not run from a package the way the bootstrap can.
+            PathBuf::from("/usr/lib/bpfjailer/bpfjailer.bpf.o"),
+            PathBuf::from("/usr/share/bpfjailer/bpfjailer.bpf.o"),
             workspace_root.join("target/bpfel-unknown-none/release/bpfjailer.bpf.o"),
             workspace_root.join("target/bpfel-unknown-none/debug/bpfjailer.bpf.o"),
             workspace_root.join("bpfjailer-bpf/target/bpfel-unknown-none/release/bpfjailer.bpf.o"),

--- a/bpfjailer-daemon/src/enrollment.rs
+++ b/bpfjailer-daemon/src/enrollment.rs
@@ -178,6 +178,32 @@ impl EnrollmentServer {
                     )),
                 }
             }
+            EnrollmentRequest::DefineRole { role } => {
+                info!("Define role request: '{}' (id={})", role.name, role.id.0);
+
+                // Registered before it is applied, so an enrollment naming
+                // this id cannot arrive between the two and be refused as
+                // unknown.
+                policy_manager.write().await.define_role(role.clone());
+
+                // The same walk the daemon runs at startup and the daemonless
+                // bootstrap runs on load, so a role defined at runtime reaches
+                // the maps by exactly the route a file-defined one does.
+                let mut sink = crate::process_tracker::TrackerSink(&process_tracker);
+                match bpfjailer_common::apply::apply_role(
+                    &mut sink,
+                    &role,
+                    &bpfjailer_common::apply::SystemResolver,
+                ) {
+                    Ok(skipped) => {
+                        for s in &skipped {
+                            error!("Role '{}': skipped {}", role.name, s);
+                        }
+                        EnrollmentResponse::Success
+                    }
+                    Err(e) => EnrollmentResponse::Error(format!("Failed to apply role: {}", e)),
+                }
+            }
             EnrollmentRequest::EnrollCgroup {
                 cgroup_path,
                 pod_id,

--- a/bpfjailer-daemon/src/policy.rs
+++ b/bpfjailer-daemon/src/policy.rs
@@ -113,6 +113,21 @@ impl PolicyManager {
         self.role_map.get(&role_id)
     }
 
+    /// Install a role at runtime.
+    ///
+    /// Roles otherwise only exist if they were in the policy file this daemon
+    /// started with, so anything deciding policy dynamically -- a controller
+    /// synthesising a role from label selectors, say -- could enroll a cgroup
+    /// only against a role someone had already written down by hand.
+    ///
+    /// Replacing an existing id is deliberate: a role's contents change when
+    /// the policy behind it changes, while its id is derived from that policy
+    /// and stays put.
+    pub fn define_role(&mut self, role: Role) {
+        self.config.roles.insert(role.name.clone(), role.clone());
+        self.role_map.insert(role.id, Arc::new(role));
+    }
+
     #[allow(dead_code)]
     pub fn get_role_by_name(&self, name: &str) -> Option<&Arc<Role>> {
         self.config


### PR DESCRIPTION
Two things stopped the daemon being usable by anything deciding policy dynamically. Both were found by running it against a real cluster.

## The daemon could not start from a package

It searched for `bpfjailer.bpf.o` only in cargo build trees:

| loader | searches installed paths |
|---|---|
| bootstrap | `/usr/lib/bpfjailer`, `/usr/share/bpfjailer` |
| daemon | **no** — build trees only |

So on a host where the bootstrap ran happily from `/usr/lib/bpfjailer/bpfjailer.bpf.o`, the daemon reported `bpfjailer.bpf.o not found in any expected location`. Fixed, with a test asserting both loaders keep searching those paths — they had drifted silently because only one of them was ever run from an install.

## Roles could not be created at runtime

Roles existed only if they were in the policy file the daemon started with. An `EnrollCgroup` naming anything else came back as:

```
Failed to enroll cgroup: Unknown role ID: 68
```

That makes dynamic enrollment useless to a controller that derives a role from label selectors — the enrollment API exists, but nothing can put a role behind it.

`DefineRole` installs or replaces one. It registers the role before applying it, so an enrollment arriving between the two is not refused as unknown, and it applies through the same `apply_role` walk that startup and the daemonless bootstrap use — so a role defined at runtime reaches the maps by exactly the route a file-defined one does, rather than by a second path that could drift.

Replacing an existing id is deliberate: a role's contents change when the policy behind it changes, while the id is derived from that policy and stays put.

## Verified end to end

On k3s v1.36.2, with an external controller deciding policy from label selectors and a node agent calling `DefineRole` then `EnrollCgroup`:

| case | result |
|---|---|
| pod under a policy denying one address | BLOCKED 3/3 |
| identical pod outside the policy, same address | ALLOWED 3/3 |
| enrolled pod, address the policy does not mention | ALLOWED 3/3 |

fmt, clippy `--deny warnings` and the test suite pass.